### PR TITLE
Delete snapshots

### DIFF
--- a/ci/deregister-private-images.sh
+++ b/ci/deregister-private-images.sh
@@ -3,12 +3,26 @@
 set -e
 set -o pipefail
 
-response=$(aws ec2 describe-images --filters "Name=name,Values=semaphore-agent-*" "Name=is-public,Values=false")
-image_ids=($(echo $response | jq '.Images[].ImageId' | xargs))
+image_ids=($(aws ec2 describe-images \
+  --filters "Name=name,Values=semaphore-agent-*" "Name=is-public,Values=false" \
+  --query 'Images[*].ImageId' \
+  --output text
+))
 
 for image_id in "${image_ids[@]}"; do
+  snapshot_id=$(aws ec2 describe-images \
+    --image-ids "${image_id}" \
+    --query 'Images[*].BlockDeviceMappings[*].Ebs.SnapshotId' \
+    --output text
+  )
+
   echo "De-registering image '${image_id}'..."
   aws ec2 deregister-image --image-id ${image_id}
+
+  if [[ -n ${snapshot_id} ]]; then
+    echo "Deleting snapshot '${snapshot_id}'..."
+    aws ec2 delete-snapshot --snapshot-id ${snapshot_id}
+  fi
 done
 
 echo "Done."


### PR DESCRIPTION
When deregistering an AMI, we need to delete its snapshot too. Otherwise, we'd remain paying for that snapshot