### PR TITLE
Use custom resource to suspend AZRebalance on auto scaling group

### DIFF
--- a/lambdas/az-rebalance-suspender/app.js
+++ b/lambdas/az-rebalance-suspender/app.js
@@ -1,0 +1,31 @@
+var aws = require("aws-sdk");
+
+function suspendAutoScalingProcess(autoScalingGroupName) {
+  console.log(`Suspending AZRebalance process for ${autoScalingGroupName}...`)
+  const autoscaling = new aws.AutoScaling();
+  const params = {
+    AutoScalingGroupName: autoScalingGroupName,
+    ScalingProcesses: ["AZRebalance"]
+  }
+
+  return new Promise(function(resolve, reject) {
+    autoscaling.suspendProcesses(params, function(err, _data) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+exports.handler = async (event, context, callback) => {
+  console.log('Received event: ', JSON.stringify(event, null, 2));
+  if (event.RequestType != "Delete") {
+    await suspendAutoScalingProcess(event.ResourceProperties.AutoScalingGroupName);
+  }
+
+  return {
+    PhysicalResourceId: "CustomResourcePhysicalID"
+  }
+};

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -1,7 +1,9 @@
+const fs = require("fs");
 const packageInfo = require("../package.json");
 const { hash } = require("./ami-hash");
 const { DependencyGroup } = require("constructs");
-const { Stack, Duration, Fn } = require("aws-cdk-lib");
+const { Stack, Duration, Fn, CustomResource } = require("aws-cdk-lib");
+const { Provider } = require("aws-cdk-lib/custom-resources");
 const { Rule, Schedule } = require("aws-cdk-lib/aws-events");
 const { LambdaFunction } = require("aws-cdk-lib/aws-events-targets");
 const { StringParameter, ParameterTier } = require("aws-cdk-lib/aws-ssm");
@@ -34,6 +36,7 @@ class AwsSemaphoreAgentStack extends Stack {
     let securityGroups = this.createSecurityGroups();
     let launchConfiguration = this.createLaunchConfiguration(ssmParameter, iamInstanceProfile, securityGroups);
     let autoScalingGroup = this.createAutoScalingGroup(launchConfiguration);
+    this.createAzRebalanceSuspender(autoScalingGroup);
 
     if (this.argumentStore.get("SEMAPHORE_AGENT_USE_DYNAMIC_SCALING") == "true") {
       let scalerLambdaRole = this.createScalerLambdaRole(defaultAWSSSMKey, autoScalingGroup);
@@ -67,7 +70,6 @@ class AwsSemaphoreAgentStack extends Stack {
   }
 
   createIamInstanceProfile(defaultAWSSSMKey) {
-    let account = Stack.of(this).account;
     let tokenKmsKey = this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_KMS_KEY") || defaultAWSSSMKey.keyId
     let policy = new Policy(this, 'instanceProfilePolicy', {
       policyName: `${this.stackName}-instance-profile-policy`,
@@ -78,7 +80,7 @@ class AwsSemaphoreAgentStack extends Stack {
             "autoscaling:SetInstanceHealth",
             "autoscaling:TerminateInstanceInAutoScalingGroup"
           ],
-          resources: [`arn:aws:autoscaling:*:${account}:autoScalingGroup:*:autoScalingGroupName/${this.stackName}-autoScalingGroup-*`]
+          resources: [`arn:aws:autoscaling:*:${this.account}:autoScalingGroup:*:autoScalingGroupName/${this.stackName}-autoScalingGroup-*`]
         }),
         new PolicyStatement({
           effect: Effect.ALLOW,
@@ -159,7 +161,6 @@ class AwsSemaphoreAgentStack extends Stack {
   }
 
   createScalerLambdaRole(defaultAWSSSMKey, autoScalingGroup) {
-    let account = Stack.of(this).account;
     let agentTokenParameterName = this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME");
     let tokenKmsKey = this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_KMS_KEY") || defaultAWSSSMKey.keyId
     let policy = new Policy(this, 'scalerLambdaPolicy', {
@@ -173,7 +174,7 @@ class AwsSemaphoreAgentStack extends Stack {
         new PolicyStatement({
           effect: Effect.ALLOW,
           actions: ["autoscaling:SetDesiredCapacity"],
-          resources: [`arn:aws:autoscaling:*:${account}:autoScalingGroup:*:autoScalingGroupName/${this.stackName}-autoScalingGroup-*`]
+          resources: [`arn:aws:autoscaling:*:${this.account}:autoScalingGroup:*:autoScalingGroupName/${this.stackName}-autoScalingGroup-*`]
         }),
         new PolicyStatement({
           effect: Effect.ALLOW,
@@ -213,7 +214,7 @@ class AwsSemaphoreAgentStack extends Stack {
     lambdaDependencies.add(lambdaRole);
 
     let lambdaFunction = new Function(this, 'scalerLambda', {
-      description: `Lambda function to dynamically scale Semaphore agents based on jobs demand`,
+      description: `Dynamically scale Semaphore agents based on jobs demand`,
       runtime: Runtime.NODEJS_14_X,
       timeout: Duration.seconds(60),
       code: new AssetCode('lambdas/agent-scaler/build'),
@@ -302,6 +303,47 @@ class AwsSemaphoreAgentStack extends Stack {
     }
 
     return autoScalingGroup;
+  }
+
+  createAzRebalanceSuspender(autoScalingGroup) {
+    let suspenderPolicy = new Policy(this, 'azRebalanceSuspenderPolicy', {
+      policyName: `${this.stackName}-az-rebalance-suspender-policy`,
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["autoscaling:SuspendProcesses"],
+          resources: [`arn:aws:autoscaling:*:${this.account}:autoScalingGroup:*:autoScalingGroupName/${this.stackName}-autoScalingGroup-*`]
+        })
+      ]
+    });
+
+    let suspenderRole = new Role(this, 'azRebalanceSuspenderRole', {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole')
+      ]
+    });
+
+    suspenderPolicy.attachToRole(suspenderRole);
+
+    let suspenderFunction = new Function(this, 'azRebalanceSuspenderLambda', {
+      description: "Suspend AZRebalance process for auto scaling group",
+      runtime: Runtime.NODEJS_14_X,
+      code: new AssetCode("lambdas/az-rebalance-suspender"),
+      handler: "app.handler",
+      role: suspenderRole
+    });
+
+    const provider = new Provider(this, "azRebalanceSuspenderProvider", {
+      onEventHandler: suspenderFunction
+    });
+
+    return new CustomResource(this, "azRebalanceSuspender", {
+      serviceToken: provider.serviceToken,
+      properties: {
+        AutoScalingGroupName: autoScalingGroup.ref
+      }
+    })
   }
 }
 


### PR DESCRIPTION
When instances are terminated, the auto scaling group might try to re-arrange the current instances so that they are properly distributed between the availability zones. That may cause agents which are in the middle of jobs to be shutdown, which is not good. Since we don't really need this feature, I'm just disabling it.

This is the only way I found to do this. It looks like you can't disable this while creating the auto scaling group, so we need a lambda-backed custom resource to suspend the `AZRebalance` auto scaling group process.