### PR TITLE
Add SEMAPHORE_ENDPOINT parameter

### DIFF
--- a/lib/argument-store.js
+++ b/lib/argument-store.js
@@ -1,11 +1,12 @@
 class ArgumentStore {
   static required = [
-    "SEMAPHORE_ORGANIZATION",
     "SEMAPHORE_AGENT_STACK_NAME",
     "SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME"
   ]
 
   static defaults = {
+    "SEMAPHORE_ENDPOINT": "",
+    "SEMAPHORE_ORGANIZATION": "",
     "SEMAPHORE_AGENT_INSTANCE_TYPE": "t2.micro",
     "SEMAPHORE_AGENT_ASG_MIN_SIZE": "0",
     "SEMAPHORE_AGENT_ASG_MAX_SIZE": "1",
@@ -51,7 +52,13 @@ class ArgumentStore {
       }
     });
 
-    // Assert related arguments are properly available
+    // If SEMAPHORE_ENDPOINT is specified, we use that value without modifying it.
+    // If SEMAPHORE_ORGANIZATION is specified, we assume the organization is located at 'semaphoreci.com'.
+    if (argumentStore.isEmpty("SEMAPHORE_ENDPOINT") && argumentStore.isEmpty("SEMAPHORE_ORGANIZATION")) {
+      throw "Either SEMAPHORE_ENDPOINT or SEMAPHORE_ORGANIZATION need be set."
+    }
+
+    // Subnets need to be specified if VPC id is
     if (!argumentStore.isEmpty("SEMAPHORE_AGENT_VPC_ID") && argumentStore.isEmpty("SEMAPHORE_AGENT_SUBNETS")) {
       throw "SEMAPHORE_AGENT_SUBNETS is required, if SEMAPHORE_AGENT_VPC_ID is set."
     }
@@ -73,6 +80,14 @@ class ArgumentStore {
 
   isEmpty(name) {
     return this.arguments[name] == "";
+  }
+
+  getSemaphoreEndpoint() {
+    if (this.isEmpty("SEMAPHORE_ENDPOINT")) {
+      return `${this.get("SEMAPHORE_ORGANIZATION")}.semaphoreci.com`;
+    }
+
+    return this.get("SEMAPHORE_ENDPOINT");
   }
 }
 

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -60,7 +60,7 @@ class AwsSemaphoreAgentStack extends Stack {
       parameterName: this.agentConfigParamName(),
       tier: ParameterTier.STANDARD,
       stringValue: JSON.stringify({
-        organization: this.argumentStore.get("SEMAPHORE_ORGANIZATION"),
+        endpoint: this.argumentStore.getSemaphoreEndpoint(),
         agentTokenParameterName: this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME"),
         disconnectAfterJob: this.argumentStore.get("SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB"),
         disconnectAfterIdleTimeout: this.argumentStore.get("SEMAPHORE_AGENT_DISCONNECT_AFTER_IDLE_TIMEOUT"),
@@ -222,7 +222,8 @@ class AwsSemaphoreAgentStack extends Stack {
       role: lambdaRole,
       environment: {
         "SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME": this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME"),
-        "SEMAPHORE_AGENT_STACK_NAME": this.stackName
+        "SEMAPHORE_AGENT_STACK_NAME": this.stackName,
+        "SEMAPHORE_ENDPOINT": this.argumentStore.getSemaphoreEndpoint()
       }
     });
 

--- a/packer/ansible/roles/agent/files/start-agent.sh
+++ b/packer/ansible/roles/agent/files/start-agent.sh
@@ -48,10 +48,10 @@ agent_token_param_name=$(echo $agent_params | jq -r '.agentTokenParameterName')
 agent_token=$(aws ssm get-parameter --region "$region" --name "$agent_token_param_name" --query Parameter.Value --output text --with-decryption)
 
 echo "Changing agent configuration..."
-organization=$(echo $agent_params | jq -r '.organization')
+endpoint=$(echo $agent_params | jq -r '.endpoint')
 disconnect_after_job=$(echo $agent_params | jq -r '.disconnectAfterJob')
 disconnect_after_idle_timeout=$(echo $agent_params | jq -r '.disconnectAfterIdleTimeout')
-yq e -i ".endpoint = \"$organization.semaphoreci.com\"" /opt/semaphore/agent/config.yaml
+yq e -i ".endpoint = \"$endpoint\"" /opt/semaphore/agent/config.yaml
 yq e -i ".token = \"$agent_token\"" /opt/semaphore/agent/config.yaml
 yq e -i ".disconnect-after-job = $disconnect_after_job" /opt/semaphore/agent/config.yaml
 yq e -i ".disconnect-after-idle-timeout = $disconnect_after_idle_timeout" /opt/semaphore/agent/config.yaml

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -21,7 +21,7 @@ describe("SSM parameter", () => {
     const template = createTemplate(basicArgumentStore());
     template.hasResourceProperties("AWS::SSM::Parameter", {
       Value: JSON.stringify({
-        organization: "test",
+        endpoint: "test.semaphoreci.com",
         agentTokenParameterName: "test-token",
         disconnectAfterJob: "true",
         disconnectAfterIdleTimeout: "300",
@@ -29,6 +29,22 @@ describe("SSM parameter", () => {
       })
     });
   })
+
+  test("sets endpoint directly", () => {
+    const argumentStore = basicArgumentStore();
+    argumentStore.set("SEMAPHORE_ENDPOINT", "someother.endpoint")
+
+    const template = createTemplate(argumentStore);
+    template.hasResourceProperties("AWS::SSM::Parameter", {
+      Value: JSON.stringify({
+        endpoint: "someother.endpoint",
+        agentTokenParameterName: "test-token",
+        disconnectAfterJob: "true",
+        disconnectAfterIdleTimeout: "300",
+        envVars: []
+      })
+    });
+  });
 
   test("disconnect-after-job and disconnect-after-idle-timeout can be set", () => {
     const argumentStore = basicArgumentStore();
@@ -38,7 +54,7 @@ describe("SSM parameter", () => {
     const template = createTemplate(argumentStore);
     template.hasResourceProperties("AWS::SSM::Parameter", {
       Value: JSON.stringify({
-        organization: "test",
+        endpoint: "test.semaphoreci.com",
         agentTokenParameterName: "test-token",
         disconnectAfterJob: "false",
         disconnectAfterIdleTimeout: "120",
@@ -54,7 +70,7 @@ describe("SSM parameter", () => {
     const template = createTemplate(argumentStore);
     template.hasResourceProperties("AWS::SSM::Parameter", {
       Value: JSON.stringify({
-        organization: "test",
+        endpoint: "test.semaphoreci.com",
         agentTokenParameterName: "test-token",
         disconnectAfterJob: "true",
         disconnectAfterIdleTimeout: "300",


### PR DESCRIPTION
- Adds a `SEMAPHORE_ENDPOINT` parameter which can be specified instead of `SEMAPHORE_ORGANIZATION`
- If set, the stack uses it without modification. If not, we assume the `SEMAPHORE_ORGANIZATION` specified is located at `semaphoreci.com`
- One of these needs to be specified. If none is, we error out.