### PR TITLE
fix: use proper instance role arn

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,7 +44,7 @@ blocks:
       jobs:
         - name: Lint ansible recipes
           commands:
-            - sudo apt-get -y install python3-venv
+            - sudo apt-get update && sudo apt-get -y install python3-venv
             - checkout
             - cache restore venv-$SEMAPHORE_GIT_BRANCH-$(checksum requirements.txt)
             - make ansible.lint

--- a/lib/argument-store.js
+++ b/lib/argument-store.js
@@ -67,6 +67,10 @@ class ArgumentStore {
       }
     });
 
+    if (argumentStore.get("SEMAPHORE_AGENT_STACK_NAME").length > 128) {
+      throw "SEMAPHORE_AGENT_STACK_NAME can be up to 128 characters long."
+    }
+
     // If SEMAPHORE_ENDPOINT is specified, we use that value without modifying it.
     // If SEMAPHORE_ORGANIZATION is specified, we assume the organization is located at 'semaphoreci.com'.
     if (argumentStore.isEmpty("SEMAPHORE_ENDPOINT") && argumentStore.isEmpty("SEMAPHORE_ORGANIZATION")) {

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -80,11 +80,6 @@ class AwsSemaphoreAgentStack extends Stack {
       statements: [
         new PolicyStatement({
           effect: Effect.ALLOW,
-          actions: ["sts:AssumeRole"],
-          resources: [`arn:aws:iam::${this.account}:role/${this.stackName}-instanceProfileRole*`]
-        }),
-        new PolicyStatement({
-          effect: Effect.ALLOW,
           actions: [
             "autoscaling:SetInstanceHealth",
             "autoscaling:TerminateInstanceInAutoScalingGroup"
@@ -145,6 +140,15 @@ class AwsSemaphoreAgentStack extends Stack {
     });
 
     policy.attachToRole(role);
+
+    // We need to add this permission here, because we need to use
+    // the exact ARN for the role. CloudFormation will truncate the
+    // stack name from the role name, to make it fit into 64 characters.
+    policy.addStatements(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["sts:AssumeRole"],
+      resources: [role.roleArn]
+    }))
 
     let instanceProfileDeps = new DependencyGroup();
     instanceProfileDeps.add(role);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "aws-cdk": "^2.17.0",
         "aws-cdk-lib": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -113,11 +113,6 @@ describe("instance profile", () => {
       PolicyDocument: {
         Statement: [
           {
-            "Action": "sts:AssumeRole",
-            "Effect": "Allow",
-            "Resource": "arn:aws:iam::dummyaccount:role/test-stack-instanceProfileRole*"
-          },
-          {
             Action: [
               "autoscaling:SetInstanceHealth",
               "autoscaling:TerminateInstanceInAutoScalingGroup"
@@ -146,6 +141,13 @@ describe("instance profile", () => {
             ],
             Effect: "Allow",
             Resource: "arn:aws:logs:*:*:log-group:/semaphore/*"
+          },
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Resource": {
+              "Fn::GetAtt": [Match.anyValue(), "Arn"]
+            }
           }
         ],
         Version: Match.anyValue()
@@ -164,11 +166,6 @@ describe("instance profile", () => {
       PolicyName: "test-stack-instance-profile-policy",
       PolicyDocument: {
         Statement: [
-          {
-            "Action": "sts:AssumeRole",
-            "Effect": "Allow",
-            "Resource": "arn:aws:iam::dummyaccount:role/test-stack-instanceProfileRole*"
-          },
           {
             Action: [
               "autoscaling:SetInstanceHealth",
@@ -211,6 +208,13 @@ describe("instance profile", () => {
               "arn:aws:s3:::test-cache-bucket/*",
               `arn:aws:s3:::test-cache-bucket`
             ]
+          },
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Resource": {
+              "Fn::GetAtt": [Match.anyValue(), "Arn"]
+            }
           }
         ],
         Version: Match.anyValue()


### PR DESCRIPTION
IAM role names can have up to [64 characters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#:~:text=A%20name%20for%20the%20IAM%20role%2C%20up%20to%2064%20characters%20in%20length), and if the stack name used leads to a name above that limit, CloudFormation truncates part of the stack name from the role name.

To address this, we reference the ARN for the instance role resource created by Cloudformation. Additionally, in order to make sure the same issue doesn't affect permissions related to the auto-scaling group name (255 characters maximum) and the SSM configuration parameter name (2048 characters maximum), we limit the `SEMAPHORE_AGENT_STACK_NAME` to 128 characters.