### PR TITLE
feat: allow custom policies to be attached to the instance profile role

### DIFF
--- a/lib/argument-store.js
+++ b/lib/argument-store.js
@@ -23,7 +23,8 @@ class ArgumentStore {
     "SEMAPHORE_AGENT_VPC_ID": "",
     "SEMAPHORE_AGENT_SUBNETS": "",
     "SEMAPHORE_AGENT_USE_DYNAMIC_SCALING": "true",
-    "SEMAPHORE_AGENT_AMI": ""
+    "SEMAPHORE_AGENT_AMI": "",
+    "SEMAPHORE_AGENT_MANAGED_POLICY_NAMES": ""
   }
 
   constructor() {

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -134,9 +134,7 @@ class AwsSemaphoreAgentStack extends Stack {
 
     let role = new Role(this, 'instanceProfileRole', {
       assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
-      managedPolicies: [
-        ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEC2RoleforSSM')
-      ]
+      managedPolicies: this.getInstanceProfileRoleManagedPolicies()
     });
 
     policy.attachToRole(role);
@@ -160,6 +158,22 @@ class AwsSemaphoreAgentStack extends Stack {
 
     iamInstanceProfile.node.addDependency(instanceProfileDeps);
     return iamInstanceProfile;
+  }
+
+  getInstanceProfileRoleManagedPolicies() {
+    let managedPolicies = [
+      ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEC2RoleforSSM')
+    ];
+
+    if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES")) {
+      this.argumentStore.get("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES")
+        .split(",")
+        .map(policyName => policyName.trim())
+        .map((policyName, index) => ManagedPolicy.fromManagedPolicyName(this, `customPolicy${index}`, policyName))
+        .forEach(policy => managedPolicies.push(policy));
+    }
+
+    return managedPolicies;
   }
 
   createSecurityGroups() {

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -99,7 +99,49 @@ describe("instance profile", () => {
           }
         ],
         Version: Match.anyValue()
-      }
+      },
+      ManagedPolicyArns: [{
+        'Fn::Join': ['', [
+          'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+        ]]
+      }]
+    });
+  })
+
+  test("role includes custom policies", () => {
+    const argumentStore = basicArgumentStore();
+    argumentStore.set("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES", "custom-policy-1,custom-policy-2")
+    const template = createTemplate(argumentStore);
+    template.hasResourceProperties("AWS::IAM::Role", {
+      AssumeRolePolicyDocument: {
+        Statement: [
+          {
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Principal: {
+              Service: "ec2.amazonaws.com"
+            }
+          }
+        ],
+        Version: Match.anyValue()
+      },
+      ManagedPolicyArns: [
+        {
+          'Fn::Join': ['', [
+            'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+          ]]
+        },
+        {
+          'Fn::Join': ['', [
+            'arn:', { Ref: 'AWS::Partition' }, ':iam::dummyaccount:policy/custom-policy-1'
+          ]]
+        },
+        {
+          'Fn::Join': ['', [
+            'arn:', { Ref: 'AWS::Partition' }, ':iam::dummyaccount:policy/custom-policy-2'
+          ]]
+        }
+      ]
     });
   })
 


### PR DESCRIPTION
Currently, there's no way to add additional permissions to the instances that will run the agents. This PR introduces a new configuration parameter `SEMAPHORE_AGENT_MANAGED_POLICY_NAMES`, which takes a comma-separated list of managed policy names to attach to the instance profile role.