### PR TITLE
fix: store SSH keys in SSM parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ cdk.out
 cdk.context.json
 
 # GitHub SSH public keys cache
-.gh_ssh_keys
+.gh_ssh_keys_*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ venv
 .cdk.staging
 cdk.out
 cdk.context.json
+
+# GitHub SSH public keys cache
+.gh_ssh_keys

--- a/bin/aws-semaphore-agent.js
+++ b/bin/aws-semaphore-agent.js
@@ -3,6 +3,7 @@
 const { App } = require('aws-cdk-lib');
 const { AwsSemaphoreAgentStack } = require('../lib/aws-semaphore-agent-stack');
 const { ArgumentStore } = require('../lib/argument-store');
+const { getKeys } = require('../lib/github-keys');
 
 const app = new App();
 const argumentStore = buildArgumentStore();
@@ -11,6 +12,7 @@ new AwsSemaphoreAgentStack(app, 'AwsSemaphoreAgentStack', {
   stackName: argumentStore.get("SEMAPHORE_AGENT_STACK_NAME"),
   description: "Semaphore agent autoscaling stack",
   argumentStore: argumentStore,
+  sshKeys: getKeys(),
   tags: {},
   env: {
     account: process.env.CDK_DEPLOY_ACCOUNT || process.env.CDK_DEFAULT_ACCOUNT,

--- a/lambdas/ssh-keys-updater/app.js
+++ b/lambdas/ssh-keys-updater/app.js
@@ -1,0 +1,107 @@
+const https = require('https');
+const aws = require('aws-sdk');
+
+function getGitHubSSHKeys() {
+  const options = {
+    hostname: "api.github.com",
+    path: "/meta",
+    method: 'GET',
+    headers: { "User-Agent": "ssh-keys-updater" }
+  }
+
+  return new Promise((resolve, reject) => {
+    let data = '';
+    https.request(options, response => {
+      if (response.statusCode !== 200) {
+        reject(`Request to get GitHub SSH keys got ${response.statusCode}`);
+        return;
+      }
+
+      response.on('data', function (chunk) {
+        data += chunk;
+      });
+
+      response.on('end', function () {
+        resolve(JSON.parse(data).ssh_keys);
+      });
+    })
+    .on('error', error => reject(error))
+    .end();
+  })
+}
+
+function getCurrentKeys(ssmClient, parameterName) {
+  console.log(`Getting current keys...`);
+  const params = { Name: parameterName };
+
+  return new Promise(function(resolve, reject) {
+    ssmClient.getParameter(params, function(err, data) {
+      if (err) {
+        if (err.name == "ParameterNotFound") {
+          console.log("Could not find parameter.");
+          resolve([]);
+        } else {
+          console.log("Error getting current keys: ", err);
+          reject(err);
+        }
+      } else {
+        resolve(JSON.parse(data.Parameter.Value));
+      }
+    });
+  });
+}
+
+function updateKeys(ssmClient, parameterName, newKeys) {
+  const params = {
+    Name: parameterName,
+    Value: JSON.stringify(newKeys),
+    Type: "String",
+    Overwrite: true,
+    Tier: "Standard",
+    DataType: "text"
+  };
+
+  return new Promise(function(resolve, reject) {
+    ssmClient.putParameter(params, function(err, data) {
+      if (err) {
+        console.log("Error updating current keys: ", err);
+        reject(err);
+      } else {
+        console.log("Successfully updated parameter", data);
+        resolve();
+      }
+    });
+  });
+}
+
+function keysAreEqual(currentKeys, newKeys) {
+  return currentKeys.length === newKeys.length && currentKeys.every((key, index) => key === newKeys[index]);
+}
+
+exports.handler = async (event, context, callback) => {
+  console.log('Received event: ', JSON.stringify(event, null, 2));
+
+  const parameterName = process.env.SSM_PARAMETER;
+  if (!parameterName) {
+    console.error("No SSM_PARAMETER specified.")
+    return {
+      statusCode: 500,
+      message: "error",
+    };
+  }
+
+  const newKeys = await getGitHubSSHKeys();
+  const ssmClient = new aws.SSM();
+  const currentKeys = await getCurrentKeys(ssmClient, parameterName);
+  if (!keysAreEqual(currentKeys, newKeys)) {
+    console.log("Keys changed. Updating...")
+    await updateKeys(ssmClient, parameterName, newKeys);
+  } else {
+    console.log("Keys haven't changed. Not updating.")
+  }
+
+  return {
+    statusCode: 200,
+    message: "sucess"
+  };
+};

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -19,6 +19,7 @@ class AwsSemaphoreAgentStack extends Stack {
     this.argumentStore = props.argumentStore;
 
     const defaultSSMKey = Alias.fromAliasName(this, 'DefaultSSMKey', 'alias/aws/ssm');
+    const sshKeysParameter = this.createSSHKeysParameter(props.sshKeys)
 
     /**
      * When processing the lifecycle hook event for the instance going into rotation,
@@ -31,7 +32,7 @@ class AwsSemaphoreAgentStack extends Stack {
      * and passed to this application through the SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME
      * environment variable.
      */
-    let ssmParameter = this.createSSMParameter();
+    let ssmParameter = this.createSSMParameter(sshKeysParameter);
     let iamInstanceProfile = this.createIamInstanceProfile(defaultSSMKey);
     let securityGroups = this.createSecurityGroups();
     let launchConfiguration = this.createLaunchConfiguration(ssmParameter, iamInstanceProfile, securityGroups);
@@ -49,7 +50,20 @@ class AwsSemaphoreAgentStack extends Stack {
     return `${this.stackName}-config`;
   }
 
-  createSSMParameter() {
+  sshKeysParamName() {
+    return `${this.stackName}-ssh-public-keys`;
+  }
+
+  createSSHKeysParameter(sshKeys) {
+    return new StringParameter(this, `SSHKeysConfigParameter`, {
+      description: 'GitHub SSH public keys used by Semaphore agent.',
+      parameterName: this.sshKeysParamName(),
+      tier: ParameterTier.STANDARD,
+      stringValue: JSON.stringify(sshKeys)
+    });
+  }
+
+  createSSMParameter(sshKeysParameter) {
     const cacheBucketName = this.argumentStore.get("SEMAPHORE_AGENT_CACHE_BUCKET_NAME");
     const envVars = cacheBucketName
       ? [
@@ -66,6 +80,7 @@ class AwsSemaphoreAgentStack extends Stack {
       stringValue: JSON.stringify({
         endpoint: this.argumentStore.getSemaphoreEndpoint(),
         agentTokenParameterName: this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME"),
+        sshKeysParameterName: sshKeysParameter.parameterName,
         disconnectAfterJob: this.argumentStore.get("SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB"),
         disconnectAfterIdleTimeout: this.argumentStore.get("SEMAPHORE_AGENT_DISCONNECT_AFTER_IDLE_TIMEOUT"),
         envVars: envVars

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -1,5 +1,6 @@
 const packageInfo = require("../package.json");
 const { hash } = require("./ami-hash");
+const { DynamicSSHKeysUpdater } = require("./dynamic-ssh-keys-updater");
 const { DependencyGroup } = require("constructs");
 const { Stack, Duration, Fn, CustomResource } = require("aws-cdk-lib");
 const { Provider } = require("aws-cdk-lib/custom-resources");
@@ -18,8 +19,12 @@ class AwsSemaphoreAgentStack extends Stack {
     super(scope, id, props);
     this.argumentStore = props.argumentStore;
 
+    new DynamicSSHKeysUpdater(this, 'sshKeysUpdater', {
+      parameterName: this.sshKeysParamName(),
+      keys: props.sshKeys
+    })
+
     const defaultSSMKey = Alias.fromAliasName(this, 'DefaultSSMKey', 'alias/aws/ssm');
-    const sshKeysParameter = this.createSSHKeysParameter(props.sshKeys)
 
     /**
      * When processing the lifecycle hook event for the instance going into rotation,
@@ -32,7 +37,7 @@ class AwsSemaphoreAgentStack extends Stack {
      * and passed to this application through the SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME
      * environment variable.
      */
-    let ssmParameter = this.createSSMParameter(sshKeysParameter);
+    let ssmParameter = this.createSSMParameter();
     let iamInstanceProfile = this.createIamInstanceProfile(defaultSSMKey);
     let securityGroups = this.createSecurityGroups();
     let launchConfiguration = this.createLaunchConfiguration(ssmParameter, iamInstanceProfile, securityGroups);
@@ -54,16 +59,7 @@ class AwsSemaphoreAgentStack extends Stack {
     return `${this.stackName}-ssh-public-keys`;
   }
 
-  createSSHKeysParameter(sshKeys) {
-    return new StringParameter(this, `SSHKeysConfigParameter`, {
-      description: 'GitHub SSH public keys used by Semaphore agent.',
-      parameterName: this.sshKeysParamName(),
-      tier: ParameterTier.STANDARD,
-      stringValue: JSON.stringify(sshKeys)
-    });
-  }
-
-  createSSMParameter(sshKeysParameter) {
+  createSSMParameter() {
     const cacheBucketName = this.argumentStore.get("SEMAPHORE_AGENT_CACHE_BUCKET_NAME");
     const envVars = cacheBucketName
       ? [
@@ -80,7 +76,7 @@ class AwsSemaphoreAgentStack extends Stack {
       stringValue: JSON.stringify({
         endpoint: this.argumentStore.getSemaphoreEndpoint(),
         agentTokenParameterName: this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME"),
-        sshKeysParameterName: sshKeysParameter.parameterName,
+        sshKeysParameterName: this.sshKeysParamName(),
         disconnectAfterJob: this.argumentStore.get("SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB"),
         disconnectAfterIdleTimeout: this.argumentStore.get("SEMAPHORE_AGENT_DISCONNECT_AFTER_IDLE_TIMEOUT"),
         envVars: envVars
@@ -106,7 +102,8 @@ class AwsSemaphoreAgentStack extends Stack {
           actions: ["ssm:GetParameter"],
           resources: [
             `arn:aws:ssm:*:*:parameter/${this.agentConfigParamName()}`,
-            `arn:aws:ssm:*:*:parameter/${this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME")}`
+            `arn:aws:ssm:*:*:parameter/${this.sshKeysParamName()}`,
+            `arn:aws:ssm:*:*:parameter/${this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME")}`,
           ]
         }),
         new PolicyStatement({

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -1,0 +1,94 @@
+const { Construct } = require("constructs");
+const { DependencyGroup } = require("constructs");
+const { Duration } = require("aws-cdk-lib");
+const { Rule, Schedule } = require("aws-cdk-lib/aws-events");
+const { LambdaFunction } = require("aws-cdk-lib/aws-events-targets");
+const { RetentionDays } = require("aws-cdk-lib/aws-logs");
+const { StringParameter, ParameterTier } = require("aws-cdk-lib/aws-ssm");
+const { Function, Runtime, AssetCode } = require("aws-cdk-lib/aws-lambda");
+const { Policy, PolicyStatement, Role, ServicePrincipal, ManagedPolicy, Effect } = require("aws-cdk-lib/aws-iam");
+
+class DynamicSSHKeysUpdater extends Construct {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+    const parameter = this.createParameter(props);
+    this.createUpdater(parameter);
+  }
+
+  createParameter(props) {
+    return new StringParameter(this, 'Parameter', {
+      description: 'GitHub SSH public keys.',
+      parameterName: props.parameterName,
+      tier: ParameterTier.STANDARD,
+      stringValue: JSON.stringify(props.keys)
+    });
+  }
+
+  createUpdater(parameter) {
+    const role = this.createUpdaterRole(parameter);
+    const lambda = this.createUpdaterLambda(role, parameter);
+    this.createEventRuleForUpdater(lambda);
+  }
+
+  createUpdaterRole(parameter) {
+    let policy = new Policy(this, 'RolePolicy', {
+      policyName: `${this.node.id}-policy`,
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["ssm:GetParameter", "ssm:PutParameter"],
+          resources: [
+            `arn:aws:ssm:*:*:parameter/${parameter.parameterName}`
+          ]
+        })
+      ]
+    });
+
+    let role = new Role(this, 'Role', {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole')
+      ]
+    });
+
+    policy.attachToRole(role);
+    return role;
+  }
+
+  createUpdaterLambda(role, parameter) {
+    const lambdaDependencies = new DependencyGroup();
+    lambdaDependencies.add(role);
+
+    let lambdaFunction = new Function(this, 'Lambda', {
+      description: `Check if GitHub SSH public keys have changed, and update parameter if so.`,
+      runtime: Runtime.NODEJS_14_X,
+      timeout: Duration.seconds(10),
+      code: new AssetCode('lambdas/ssh-keys-updater'),
+      handler: 'app.handler',
+      role: role,
+      logRetention: RetentionDays.ONE_MONTH,
+      environment: {
+        "SSM_PARAMETER": parameter.parameterName
+      }
+    });
+
+    lambdaFunction.node.addDependency(lambdaDependencies);
+    return lambdaFunction;
+  }
+
+  createEventRuleForUpdater(lambda) {
+    const ruleDependencies = new DependencyGroup();
+    ruleDependencies.add(lambda);
+
+    const rule = new Rule(this, 'EventRule', {
+      description: `Rule to dynamically invoke lambda function to check GitHub public SSH keys.`,
+      schedule: Schedule.expression('rate(1 hour)'),
+      targets: [new LambdaFunction(lambda)]
+    });
+
+    rule.node.addDependency(ruleDependencies);
+    return rule;
+  }
+}
+
+module.exports = { DynamicSSHKeysUpdater }

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -12,7 +12,7 @@ class DynamicSSHKeysUpdater extends Construct {
   constructor(scope, id, props) {
     super(scope, id, props);
     const parameter = this.createParameter(props);
-    this.createUpdater(parameter);
+    this.createUpdater(props.parameterName);
   }
 
   createParameter(props) {
@@ -24,13 +24,13 @@ class DynamicSSHKeysUpdater extends Construct {
     });
   }
 
-  createUpdater(parameter) {
-    const role = this.createUpdaterRole(parameter);
-    const lambda = this.createUpdaterLambda(role, parameter);
+  createUpdater(parameterName) {
+    const role = this.createUpdaterRole(parameterName);
+    const lambda = this.createUpdaterLambda(role, parameterName);
     this.createEventRuleForUpdater(lambda);
   }
 
-  createUpdaterRole(parameter) {
+  createUpdaterRole(parameterName) {
     let policy = new Policy(this, 'RolePolicy', {
       policyName: `${this.node.id}-policy`,
       statements: [
@@ -38,7 +38,7 @@ class DynamicSSHKeysUpdater extends Construct {
           effect: Effect.ALLOW,
           actions: ["ssm:GetParameter", "ssm:PutParameter"],
           resources: [
-            `arn:aws:ssm:*:*:parameter/${parameter.parameterName}`
+            `arn:aws:ssm:*:*:parameter/${parameterName}`
           ]
         })
       ]
@@ -55,12 +55,12 @@ class DynamicSSHKeysUpdater extends Construct {
     return role;
   }
 
-  createUpdaterLambda(role, parameter) {
+  createUpdaterLambda(role, parameterName) {
     const lambdaDependencies = new DependencyGroup();
     lambdaDependencies.add(role);
 
     let lambdaFunction = new Function(this, 'Lambda', {
-      description: `Check if GitHub SSH public keys have changed, and update parameter if so.`,
+      description: `Check if GitHub SSH public keys have changed.`,
       runtime: Runtime.NODEJS_14_X,
       timeout: Duration.seconds(10),
       code: new AssetCode('lambdas/ssh-keys-updater'),
@@ -68,7 +68,7 @@ class DynamicSSHKeysUpdater extends Construct {
       role: role,
       logRetention: RetentionDays.ONE_MONTH,
       environment: {
-        "SSM_PARAMETER": parameter.parameterName
+        "SSM_PARAMETER": parameterName
       }
     });
 

--- a/lib/github-keys.js
+++ b/lib/github-keys.js
@@ -1,0 +1,33 @@
+const path = require("path");
+const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { execSync } = require('child_process');
+
+// To make sure we don't always hit the Github API
+// to determine its keys, we cache the keys in a local file.
+// TODO: add timestamp to file.
+const cacheFilePath = path.resolve(__dirname, '../.gh_ssh_keys')
+
+function getKeys() {
+  if (existsSync(cacheFilePath)) {
+    console.log(`==> GitHub SSH keys found locally.`);
+    return JSON.parse(readFileSync(cacheFilePath).toString())
+  }
+
+  console.log(`==> GitHub SSH keys not found locally. Fetching ...`);
+
+  // TODO: handle command error
+  meta = execSync(`curl -s https://api.github.com/meta`, {
+    cwd: path.resolve(__dirname, '../')
+  });
+
+  // TODO: handle missing keys
+  let keys = JSON.parse(meta.toString()).ssh_keys
+    .map(key => `github.com ${key}`)
+
+  // TODO: handle error
+  writeFileSync(cacheFilePath, JSON.stringify(keys))
+
+  return keys
+}
+
+module.exports = { getKeys }

--- a/lib/github-keys.js
+++ b/lib/github-keys.js
@@ -1,20 +1,54 @@
 const path = require("path");
-const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { readFileSync, writeFileSync, readdirSync } = require('fs');
 const { execSync } = require('child_process');
 
 // To make sure we don't always hit the Github API
 // to determine its keys, we cache the keys in a local file.
-// TODO: add timestamp to file.
-const cacheFilePath = path.resolve(__dirname, '../.gh_ssh_keys')
+const cacheFilePrefix = ".gh_ssh_keys";
+
+// We expire the cache file after 1 hour.
+const expirationPeriod = 60 * 60;
 
 function getKeys() {
-  if (existsSync(cacheFilePath)) {
-    console.log(`==> GitHub SSH keys found locally.`);
-    return JSON.parse(readFileSync(cacheFilePath).toString())
+  let cachedFile = findCacheFile()
+  if (!cachedFile) {
+    const newFilePath = newCacheFileName()
+    const newFileName = path.basename(newFilePath)
+    console.log(`==> GitHub SSH keys not found locally. Fetching and storing at '${newFileName}' ...`);
+    return fetchAndStore(newFilePath)
   }
 
-  console.log(`==> GitHub SSH keys not found locally. Fetching ...`);
+  if (cachedFile.expired) {
+    const newFilePath = newCacheFileName()
+    const newFileName = path.basename(newFilePath)
+    console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}', but expired. Fetching and storing at '${newFileName}' ...`);
+    return fetchAndStore(newFilePath)
+  }
 
+  console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}'.`);
+  return JSON.parse(readFileSync(cachedFile.fileName).toString())
+}
+
+function findCacheFile() {
+  const fileName = readdirSync(path.resolve(__dirname, ".."))
+    .find(fileName => fileName.startsWith(cacheFilePrefix))
+
+  if (fileName) {
+    const fileNameParts = fileName.split("_")
+    const timestamp = parseInt(fileNameParts[fileNameParts.length - 1])
+    const expireAt = (timestamp + expirationPeriod)
+    const now = epochSeconds()
+    if (now < expireAt) {
+      return {fileName, expired: false}
+    }
+
+    return {fileName, expired: true}
+  }
+
+  return null
+}
+
+function fetchAndStore(filePath) {
   // TODO: handle command error
   meta = execSync(`curl -s https://api.github.com/meta`, {
     cwd: path.resolve(__dirname, '../')
@@ -22,12 +56,18 @@ function getKeys() {
 
   // TODO: handle missing keys
   let keys = JSON.parse(meta.toString()).ssh_keys
-    .map(key => `github.com ${key}`)
 
   // TODO: handle error
-  writeFileSync(cacheFilePath, JSON.stringify(keys))
-
+  writeFileSync(filePath, JSON.stringify(keys))
   return keys
+}
+
+function newCacheFileName() {
+  return path.resolve(__dirname, '..', `${cacheFilePrefix}_${epochSeconds()}`)
+}
+
+function epochSeconds() {
+  return Math.floor(new Date().getTime() / 1000)
 }
 
 module.exports = { getKeys }

--- a/lib/github-keys.js
+++ b/lib/github-keys.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { readFileSync, writeFileSync, readdirSync } = require('fs');
+const { readFileSync, writeFileSync, readdirSync, unlinkSync } = require('fs');
 const { execSync } = require('child_process');
 
 // To make sure we don't always hit the Github API
@@ -22,7 +22,9 @@ function getKeys() {
     const newFilePath = newCacheFileName()
     const newFileName = path.basename(newFilePath)
     console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}', but expired. Fetching and storing at '${newFileName}' ...`);
-    return fetchAndStore(newFilePath)
+    const keys = fetchAndStore(newFilePath)
+    unlinkSync(path.resolve(__dirname, '..', cachedFile.fileName))
+    return keys
   }
 
   console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}'.`);
@@ -49,15 +51,8 @@ function findCacheFile() {
 }
 
 function fetchAndStore(filePath) {
-  // TODO: handle command error
-  meta = execSync(`curl -s https://api.github.com/meta`, {
-    cwd: path.resolve(__dirname, '../')
-  });
-
-  // TODO: handle missing keys
+  meta = execSync(`curl -s https://api.github.com/meta`);
   let keys = JSON.parse(meta.toString()).ssh_keys
-
-  // TODO: handle error
   writeFileSync(filePath, JSON.stringify(keys))
   return keys
 }

--- a/packer/linux/ansible/roles/agent/files/start-agent.sh
+++ b/packer/linux/ansible/roles/agent/files/start-agent.sh
@@ -18,7 +18,16 @@ on_failure() {
 }
 
 #
-# Retry a command for a while.
+# Generates a random number of seconds between 0.750s - 5s.
+#
+random_sleep() {
+  random_number=$(shuf -i 750-5000 -n 1)
+  delay=$(echo "$random_number / 1000.0" | bc -l)
+  echo "$delay"
+}
+
+#
+# Retry a command for a while, with random sleeps after failures.
 #
 retry_cmd() {
   local __cmd__=$1
@@ -38,6 +47,7 @@ retry_cmd() {
     if [[ $__i__ == $__max_retries__ ]]; then
       return $__result__
     else
+      __sleep__=$(random_sleep)
       sleep $__sleep__
     fi
   done

--- a/packer/linux/ansible/roles/agent/files/start-agent.sh
+++ b/packer/linux/ansible/roles/agent/files/start-agent.sh
@@ -2,10 +2,14 @@
 
 set -eo pipefail
 
+#
+# If anything goes wrong with the instance startup,
+# we make the instance unhealthy, so the auto scaling group can rotate it.
+#
 on_failure() {
   local exit_code=$1
   if [[ $exit_code != 0 ]] ; then
-    token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
+    token=$(fetch_idms_token)
     instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
     aws autoscaling set-instance-health \
       --instance-id "${instance_id}" \
@@ -13,6 +17,205 @@ on_failure() {
   fi
 }
 
+#
+# Retry a command for a while.
+#
+retry_cmd() {
+  local __cmd__=$1
+  local __result__=0
+  local __max_retries__=30
+  local __sleep__=1
+
+  for __i__ in $(seq 1 $__max_retries__); do
+    __output__=$(eval "$__cmd__")
+    __result__="$?"
+
+    if [ $__result__ -eq "0" ]; then
+      echo $__output__
+      return 0
+    fi
+
+    if [[ $__i__ == $__max_retries__ ]]; then
+      return $__result__
+    else
+      sleep $__sleep__
+    fi
+  done
+}
+
+#
+# Fetch an instance metadata service token.
+# This token is required for all the other requests to the instance metadata service endpoints.
+#
+fetch_idms_token() {
+  local __token__=$(curl \
+    -X PUT \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" \
+    --fail \
+    --silent \
+    --show-error \
+    --location "http://169.254.169.254/latest/api/token"
+  )
+
+  echo $__token__
+}
+
+#
+# Fetch the agent configuration parameters from the SSM parameter store.
+#
+fetch_agent_params() {
+  local __region__=$1
+  local __param_name__=$2
+
+  local __agent_params__=$(retry_cmd "aws ssm get-parameter \
+    --region '$__region__' \
+    --name '$__param_name__' \
+    --query Parameter.Value \
+    --output text"
+  )
+
+  if [[ $? != 0 ]]; then
+    echo "Error fetching agent params."
+    return 1
+  else
+    echo $__agent_params__
+    return 0
+  fi
+}
+
+#
+# Fetch the agent registration token from the SSM parameter store.
+#
+fetch_agent_token() {
+  local __region__=$1
+  local __param_name__=$2
+  local __token__=$(retry_cmd "aws ssm get-parameter \
+    --region '$__region__' \
+    --name '$__param_name__' \
+    --query Parameter.Value \
+    --output text \
+    --with-decryption"
+  )
+
+  if [[ $? != 0 ]]; then
+    echo "Error fetching agent token."
+    return 1
+  else
+    echo $__token__
+    return 0
+  fi
+}
+
+#
+# Update the agent configuration YAML,
+# using the agent's configuration parameters and registration token.
+#
+change_agent_config() {
+  local __agent_params__=$1
+  local __agent_token__=$2
+
+  echo "Changing agent configuration..."
+
+  # Find parameter values from the SSM agent configuration parameter
+  local __endpoint__=$(echo $__agent_params__ | jq -r '.endpoint')
+  local __disconnect_after_job__=$(echo $__agent_params__ | jq -r '.disconnectAfterJob')
+  local __disconnect_after_idle_timeout__=$(echo $__agent_params__ | jq -r '.disconnectAfterIdleTimeout')
+
+  # Update agent YAML configuration
+  yq e -i ".endpoint = \"$__endpoint__\"" /opt/semaphore/agent/config.yaml
+  yq e -i ".token = \"$__agent_token__\"" /opt/semaphore/agent/config.yaml
+  yq e -i ".disconnect-after-job = $__disconnect_after_job__" /opt/semaphore/agent/config.yaml
+  yq e -i ".disconnect-after-idle-timeout = $__disconnect_after_idle_timeout__" /opt/semaphore/agent/config.yaml
+  echo $__agent_params__ | jq '.envVars[]' | xargs -I {} yq e -P -i '.env-vars = .env-vars + "{}"' /opt/semaphore/agent/config.yaml
+
+  # Update agent configuration file permissions
+  sudo chown semaphore:semaphore /opt/semaphore/agent/config.yaml
+}
+
+#
+# Configure the .aws folder for the semaphore user.
+#
+configure_aws_folder() {
+  local __region__=$1
+  local __token__=$(fetch_idms_token)
+
+  # Get the name of the role attached to the instance profile.
+  local __role_name__=$(curl \
+    -H "X-aws-ec2-metadata-token: $__token__" \
+    --fail \
+    --silent \
+    --show-error \
+    --location "http://169.254.169.254/latest/meta-data/iam/security-credentials"
+  )
+
+  # Get the account ID
+  local __account_id__=$(curl \
+    -H "X-aws-ec2-metadata-token: $__token__" \
+    --fail \
+    --silent \
+    --show-error \
+    --location "http://169.254.169.254/latest/dynamic/instance-identity/document" \
+    | jq -r '.accountId'
+  )
+
+  # Create the .aws folder for the semaphore user
+  echo "Creating the .aws folder..."
+  sudo mkdir -p /home/semaphore/.aws
+
+  # Create the AWS CLI configuration.
+  # We use a specific semaphore__agent-aws-stack-instance-profile AWS CLI profile,
+  # in order to make sure we are always using the instance profile role's credentials
+  # when calling out to the AWS API in other scripts/CLIs.
+  echo "Creating the .aws/config file..."
+  sudo tee -a /home/semaphore/.aws/config > /dev/null <<EOT
+[default]
+region = $__region__
+
+[profile semaphore__agent-aws-stack-instance-profile]
+region = $__region__
+role_arn = arn:aws:iam::$__account_id__:role/$__role_name__
+credential_source = Ec2InstanceMetadata
+EOT
+
+  # Use the proper permissions for the .aws folder
+  echo "Updating .aws folder's permissions..."
+  sudo chown -R semaphore:semaphore /home/semaphore/.aws
+}
+
+#
+# Fetch the SSH public keys from the SSM parameter store,
+# and place them into the .ssh/known_hosts folder.
+#
+configure_known_hosts() {
+  local __region__=$1
+  local __param_name__=$2
+
+  echo "Creating .ssh folder..."
+  sudo mkdir -p /home/semaphore/.ssh
+
+  echo "Fetching SSH keys from SSM parameter '$__param_name__'..."
+  local __keys__=$(retry_cmd "aws ssm get-parameter \
+    --region '$__region__' \
+    --name '$__param_name__' \
+    --query Parameter.Value \
+    --output text"
+  )
+
+  if [[ $? != 0 ]]; then
+    echo "Error fetching SSH keys."
+    return 1
+  fi
+
+  echo "Adding keys to .ssh/known_hosts..."
+  echo $__keys__ | jq -r '.[]' | sed 's/^/github.com /' | sudo tee -a /home/semaphore/.ssh/known_hosts
+
+  echo "Updating permissions on .ssh folder..."
+  sudo chown -R semaphore:semaphore /home/semaphore/.ssh
+}
+
+#
+# Main script starts here.
+#
 trap 'on_failure $? $LINENO' EXIT
 
 agent_config_param_name=$1
@@ -21,51 +224,36 @@ if [[ -z "$agent_config_param_name" ]]; then
   exit 1
 fi
 
-token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
-region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
+token=$(fetch_idms_token)
+region=$(curl \
+  -H "X-aws-ec2-metadata-token: $token" \
+  --fail \
+  --silent \
+  --show-error \
+  --location "http://169.254.169.254/latest/meta-data/placement/region"
+)
 
-echo "Fetching agent params..."
-agent_params=$(aws ssm get-parameter --region "$region" --name "$agent_config_param_name" --query Parameter.Value --output text)
+# The parameters required for the agent configuration are stored in an SSM parameter.
+# We need to fetch them before proceeding with anything else.
+echo "Fetching agent params from SSM parameter '$agent_config_param_name'..."
+agent_params=$(fetch_agent_params $region $agent_config_param_name)
 
-echo "Adding github SSH keys to known_hosts..."
-sudo mkdir -p /home/semaphore/.ssh
+# In order for code checkout to work properly,
+# we need to let the instance know about GitHub's public SSH keys.
 ssh_keys_param=$(echo $agent_params | jq -r '.sshKeysParameterName')
-ssh_keys=$(aws ssm get-parameter --region "$region" --name "$ssh_keys_param" --query Parameter.Value --output text)
-echo $ssh_keys | jq -r '.[]' | sed 's/^/github.com /' | sudo tee -a /home/semaphore/.ssh/known_hosts
-sudo chown -R semaphore:semaphore /home/semaphore/.ssh
+configure_known_hosts $region $ssh_keys_param
 
-echo "Configuring .aws folder"
-role_name=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/iam/security-credentials")
-account_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/dynamic/instance-identity/document" | jq -r '.accountId')
+# In order for the agent hooks and the cache CLI to work properly,
+# we need to configure the .aws folder.
+configure_aws_folder $region
 
-sudo mkdir -p /home/semaphore/.aws
-sudo tee -a /home/semaphore/.aws/config > /dev/null <<EOT
-[default]
-region = $region
-
-[profile semaphore__agent-aws-stack-instance-profile]
-region = $region
-role_arn = arn:aws:iam::$account_id:role/$role_name
-credential_source = Ec2InstanceMetadata
-EOT
-sudo chown -R semaphore:semaphore /home/semaphore/.aws
-
-echo "Fetching agent token..."
+# Fetch agent token from its SSM parameter,
+# and update the agent configuration YAML.
 agent_token_param_name=$(echo $agent_params | jq -r '.agentTokenParameterName')
-agent_token=$(aws ssm get-parameter --region "$region" --name "$agent_token_param_name" --query Parameter.Value --output text --with-decryption)
+echo "Fetching agent token from SSM parameter '$agent_token_param_name'..."
+agent_token=$(fetch_agent_token $region $agent_token_param_name)
+change_agent_config $agent_params $agent_token
 
-echo "Changing agent configuration..."
-endpoint=$(echo $agent_params | jq -r '.endpoint')
-disconnect_after_job=$(echo $agent_params | jq -r '.disconnectAfterJob')
-disconnect_after_idle_timeout=$(echo $agent_params | jq -r '.disconnectAfterIdleTimeout')
-yq e -i ".endpoint = \"$endpoint\"" /opt/semaphore/agent/config.yaml
-yq e -i ".token = \"$agent_token\"" /opt/semaphore/agent/config.yaml
-yq e -i ".disconnect-after-job = $disconnect_after_job" /opt/semaphore/agent/config.yaml
-yq e -i ".disconnect-after-idle-timeout = $disconnect_after_idle_timeout" /opt/semaphore/agent/config.yaml
-echo $agent_params | jq '.envVars[]' | xargs -I {} yq e -P -i '.env-vars = .env-vars + "{}"' /opt/semaphore/agent/config.yaml
-sudo chown semaphore:semaphore /opt/semaphore/agent/config.yaml
-
+# After upgrading the agent configuration, start the agent systemd service.
 echo "Starting agent..."
 sudo systemctl start semaphore-agent
-
-echo "Done."

--- a/packer/windows/scripts/configure-github-ssh-keys.ps1
+++ b/packer/windows/scripts/configure-github-ssh-keys.ps1
@@ -1,14 +1,17 @@
 $ProgressPreference = 'SilentlyContinue'
 $ErrorActionPreference = 'Stop'
 
+$SSHKeys = $args[0]
+if (-not $SSHKeys) {
+  throw "SSH Keys are required."
+}
+
+$keys = $SSHKeys | jq -r '.[]'
+$knownHosts = $keys -replace '^', 'github.com '
 Write-Output "Adding github SSH keys to known_hosts..."
 if (-not (Test-Path "$HOME\.ssh")) {
   New-Item -ItemType Directory -Path "$HOME\.ssh" > $null
 }
-
-$metaResponse = (Invoke-WebRequest -UseBasicParsing "https://api.github.com/meta").Content
-$keys = $metaResponse | jq -r '.ssh_keys[]'
-$knownHosts = $keys -replace '^', 'github.com '
 
 $KnownHostsPath = "$HOME\.ssh\known_hosts"
 if (-not (Test-Path $KnownHostsPath)) {

--- a/packer/windows/scripts/start-agent.ps1
+++ b/packer/windows/scripts/start-agent.ps1
@@ -18,9 +18,6 @@ function Retry-Command {
 
     [Parameter(Mandatory=$false)]
     [int]$MaxAttempts = 30,
-
-    [Parameter(Mandatory=$false)]
-    [int]$DelayInSeconds = 1
   )
 
   Begin {
@@ -35,7 +32,8 @@ function Retry-Command {
         return
       } catch {
         Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
-        Start-Sleep -Seconds $DelayInSeconds
+        $delay = Get-Random -Minimum 750 -Maximum 5000
+        Start-Sleep -Milliseconds $delay
       }
     } while ($currentAttempt -lt $MaxAttempts)
 

--- a/packer/windows/scripts/start-agent.ps1
+++ b/packer/windows/scripts/start-agent.ps1
@@ -17,7 +17,7 @@ function Retry-Command {
     [scriptblock]$ScriptBlock,
 
     [Parameter(Mandatory=$false)]
-    [int]$MaxAttempts = 30,
+    [int]$MaxAttempts = 30
   )
 
   Begin {

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -23,6 +23,7 @@ describe("SSM parameter", () => {
       Value: JSON.stringify({
         endpoint: "test.semaphoreci.com",
         agentTokenParameterName: "test-token",
+        sshKeysParameterName: "test-stack-ssh-public-keys",
         disconnectAfterJob: "true",
         disconnectAfterIdleTimeout: "300",
         envVars: []
@@ -39,6 +40,7 @@ describe("SSM parameter", () => {
       Value: JSON.stringify({
         endpoint: "someother.endpoint",
         agentTokenParameterName: "test-token",
+        sshKeysParameterName: "test-stack-ssh-public-keys",
         disconnectAfterJob: "true",
         disconnectAfterIdleTimeout: "300",
         envVars: []
@@ -56,6 +58,7 @@ describe("SSM parameter", () => {
       Value: JSON.stringify({
         endpoint: "test.semaphoreci.com",
         agentTokenParameterName: "test-token",
+        sshKeysParameterName: "test-stack-ssh-public-keys",
         disconnectAfterJob: "false",
         disconnectAfterIdleTimeout: "120",
         envVars: []
@@ -72,6 +75,7 @@ describe("SSM parameter", () => {
       Value: JSON.stringify({
         endpoint: "test.semaphoreci.com",
         agentTokenParameterName: "test-token",
+        sshKeysParameterName: "test-stack-ssh-public-keys",
         disconnectAfterJob: "true",
         disconnectAfterIdleTimeout: "300",
         envVars: [
@@ -125,6 +129,7 @@ describe("instance profile", () => {
             Effect: "Allow",
             Resource: [
               "arn:aws:ssm:*:*:parameter/test-stack-config",
+              "arn:aws:ssm:*:*:parameter/test-stack-ssh-public-keys",
               "arn:aws:ssm:*:*:parameter/test-token"
             ]
           },
@@ -179,6 +184,7 @@ describe("instance profile", () => {
             Effect: "Allow",
             Resource: [
               "arn:aws:ssm:*:*:parameter/test-stack-config",
+              "arn:aws:ssm:*:*:parameter/test-stack-ssh-public-keys",
               "arn:aws:ssm:*:*:parameter/test-token"
             ]
           },
@@ -626,6 +632,7 @@ function createTemplateWithOS(argumentStore, os) {
 
   const stack = new AwsSemaphoreAgentStack(app, 'MyTestStack', {
     argumentStore,
+    sshKeys: [],
     stackName: "test-stack",
     env: { account, region }
   });

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -6,7 +6,7 @@ const { App } = require("aws-cdk-lib");
 const { ParameterTier } = require("aws-cdk-lib/aws-ssm");
 const { Template, Match } = require("aws-cdk-lib/assertions");
 
-describe("SSM parameter", () => {
+describe("SSM parameter for agent configuration", () => {
   test("name is prefixed with stack name", () => {
     const template = createTemplate(basicArgumentStore());
     template.hasResourceProperties("AWS::SSM::Parameter", {
@@ -86,6 +86,19 @@ describe("SSM parameter", () => {
       })
     });
   });
+})
+
+describe("SSM parameter for SSH keys", () => {
+  test("name is prefixed with stack name", () => {
+    const template = createTemplate(basicArgumentStore());
+    template.hasResourceProperties("AWS::SSM::Parameter", {
+      Type: "String",
+      Name: "test-stack-ssh-public-keys",
+      Description: "GitHub SSH public keys.",
+      Tier: ParameterTier.STANDARD,
+      Value: '["ssh-key1","ssh-key2"]'
+    });
+  })
 })
 
 describe("instance profile", () => {
@@ -525,6 +538,59 @@ describe("scaler lambda", () => {
   })
 })
 
+describe("SSH keys updater lambda", () => {
+  test("all needed properties are set", () => {
+    const template = createTemplate(basicArgumentStore());
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Description: "Check if GitHub SSH public keys have changed.",
+      Runtime: "nodejs14.x",
+      Timeout: 10,
+      Code: Match.anyValue(),
+      Handler: "app.handler",
+      Environment: {
+        Variables: {
+          SSM_PARAMETER: "test-stack-ssh-public-keys"
+        }
+      },
+      Role: Match.anyValue()
+    });
+  })
+
+  test("rule to schedule lambda execution is created", () => {
+    const template = createTemplate(basicArgumentStore());
+    template.hasResourceProperties("AWS::Events::Rule", {
+      Description: "Rule to dynamically invoke lambda function to check GitHub public SSH keys.",
+      ScheduleExpression: "rate(1 hour)",
+      State: "ENABLED",
+      Targets: Match.anyValue()
+    });
+  })
+
+  test("proper permissions created", () => {
+    const argumentStore = basicArgumentStore();
+    argumentStore.set("SEMAPHORE_AGENT_TOKEN_KMS_KEY", "dummy-kms-key-id");
+
+    const template = createTemplate(argumentStore);
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyName: "sshKeysUpdater-policy",
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: [
+              "ssm:GetParameter",
+              "ssm:PutParameter"
+            ],
+            Effect: "Allow",
+            Resource: "arn:aws:ssm:*:*:parameter/test-stack-ssh-public-keys"
+          }
+        ],
+        Version: Match.anyValue()
+      },
+      Roles: Match.anyValue(),
+    });
+  })
+})
+
 describe("vpc and subnets", () => {
   test("uses default vpc if none is given", () => {
     const template = createTemplate(basicArgumentStore());
@@ -632,7 +698,7 @@ function createTemplateWithOS(argumentStore, os) {
 
   const stack = new AwsSemaphoreAgentStack(app, 'MyTestStack', {
     argumentStore,
-    sshKeys: [],
+    sshKeys: ["ssh-key1", "ssh-key2"],
     stackName: "test-stack",
     env: { account, region }
   });


### PR DESCRIPTION
Currently, the way we provision the Github SSH public keys can lead to issues on agents that run in private subnets. [The Github API](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-personal-accounts) has a 60 requests per hour limit, which can be an issue if all the requests are being routed through a NAT gateway. So, we need a better way of handling those SSH keys.

## Storing/retrieving SSH keys

This PR introduces a new SSM parameter to store the Github SSH keys. The parameter is initialized with the values from Github's API when bootstrapping/deploying the stack. To make sure we don't lead into rate limits for bootstrap/deploys as well, we cache the SSH keys in a local file for subsequent runs.

Another considerations:
- **SSM parameter size limitations**: standard SSM parameters have a 4k size limit. The current set of keys use ~600B, so we should be fine.
- **Throughput**:  we can fetch SSM parameter at [40 req/s](https://docs.aws.amazon.com/general/latest/gr/ssm.html#limits_ssm). In order to address the unlikely scenario of a lot of agents starting up at the exact same second, we always retry the API calls from the startup scripts. In case that's still not enough, [high throughput](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-throughput.html) can be enabled in the AWS account, which increases the rate to 3000 req/s.
- **Why not use an S3 bucket?**: alternatively, we could also use an object in a S3 bucket. The CDK offers something called [Assets](https://docs.aws.amazon.com/cdk/v2/guide/assets.html), which makes it easy to create and expose resources to applications. However, these assets seem to be good for read-only resources only. Since we need to also update the keys dynamically in a lambda, we can't go that way. The CDK still offers [another way to deploy assets](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3_deployment-readme.html) to a different bucket during deployment, but that's not as straightforward.

## Automatically detecing SSH key changes

To make sure we keep the Github's keys updated, we use a lambda to check Github's API and update the SSM parameter. The lambda runs hourly.

### Example runs

Lambda run when keys haven't changed:

```
2022-08-01T23:00:30.685Z	8bf21b7f-0242-4f60-8b00-eee49b5f031d	INFO	Getting current keys...
2022-08-01T23:00:31.366Z	8bf21b7f-0242-4f60-8b00-eee49b5f031d	INFO	Keys haven't changed. Not updating.
```

Lambda run when keys changed:

```
2022-08-01T22:00:30.710Z	65e884ff-81f7-4338-b5be-09102e9082ed	INFO	Getting current keys...
2022-08-01T22:00:31.468Z	65e884ff-81f7-4338-b5be-09102e9082ed	INFO	Keys changed. Updating...
2022-08-01T22:00:31.628Z	65e884ff-81f7-4338-b5be-09102e9082ed	INFO	Successfully updated parameter { Version: 3, Tier: 'Standard' }
```