### PR TITLE
feat: publish occupancy metrics to CloudWatch

### DIFF
--- a/lambdas/agent-scaler/app.js
+++ b/lambdas/agent-scaler/app.js
@@ -1,6 +1,7 @@
 const https = require('https');
 const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");
 const { AutoScalingClient, DescribeAutoScalingGroupsCommand, SetDesiredCapacityCommand } = require("@aws-sdk/client-auto-scaling");
+const { CloudWatchClient, PutMetricDataCommand } = require("@aws-sdk/client-cloudwatch");
 
 function getAgentTypeToken(tokenParameterName) {
   const ssmClient = new SSMClient();
@@ -81,6 +82,36 @@ function setAsgDesiredCapacity(autoScalingClient, asgName, desiredCapacity) {
   });
 }
 
+function publishOccupancyMetrics(occupancy) {
+  const cloudwatchClient = new CloudWatchClient();
+  const metricData = Object.keys(occupancy)
+    .map((count, state) => {
+      return {
+        MetricName: `semaphore.jobs`,
+        Value: count,
+        Unit: "Count",
+        Timestamp: new Date(),
+        Dimensions: [
+          {Name: "State", Value: state}
+        ]
+      }
+    });
+
+  console.log(`Publishing metrics to CloudWatch: ${metricData}`);
+
+  return new Promise(function(resolve, reject) {
+    const command = new PutMetricDataCommand({ MetricData: metricData, Namespace: "Semaphore" });
+    cloudwatchClient.send(command, function(err, data) {
+      if (err) {
+        console.log("Error publishing metrics: ", err);
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+}
+
 function getAgentTypeOccupancy(token, semaphoreEndpoint) {
   const options = {
     hostname: semaphoreEndpoint,
@@ -141,6 +172,7 @@ const tick = async (agentTokenParameterName, stackName, autoScalingClient, semap
   try {
     const agentTypeToken = await getAgentTypeToken(agentTokenParameterName);
     const occupancy = await getAgentTypeOccupancy(agentTypeToken, semaphoreEndpoint);
+    await publishOccupancyMetrics(occupancy);
     const asg = await describeAsg(autoScalingClient, stackName);
     await scaleUpIfNeeded(autoScalingClient, asg.name, occupancy, asg);
   } catch (e) {

--- a/lambdas/agent-scaler/app.js
+++ b/lambdas/agent-scaler/app.js
@@ -1,4 +1,5 @@
 const https = require('https');
+const utils = require("util");
 const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");
 const { AutoScalingClient, DescribeAutoScalingGroupsCommand, SetDesiredCapacityCommand } = require("@aws-sdk/client-auto-scaling");
 const { CloudWatchClient, PutMetricDataCommand } = require("@aws-sdk/client-cloudwatch");
@@ -85,19 +86,19 @@ function setAsgDesiredCapacity(autoScalingClient, asgName, desiredCapacity) {
 function publishOccupancyMetrics(occupancy) {
   const cloudwatchClient = new CloudWatchClient();
   const metricData = Object.keys(occupancy)
-    .map((count, state) => {
+    .map(state => {
       return {
-        MetricName: `semaphore.jobs`,
-        Value: count,
+        MetricName: `JobCount`,
+        Value: occupancy[state],
         Unit: "Count",
         Timestamp: new Date(),
         Dimensions: [
-          {Name: "State", Value: state}
+          {Name: "JobState", Value: state}
         ]
       }
     });
 
-  console.log(`Publishing metrics to CloudWatch: ${metricData}`);
+  console.log(`Publishing metrics to CloudWatch: ${utils.inspect(metricData)}`);
 
   return new Promise(function(resolve, reject) {
     const command = new PutMetricDataCommand({ MetricData: metricData, Namespace: "Semaphore" });

--- a/lambdas/agent-scaler/package-lock.json
+++ b/lambdas/agent-scaler/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@aws-sdk/client-auto-scaling": "^3.49.0",
+        "@aws-sdk/client-cloudwatch": "^3.49.0",
         "@aws-sdk/client-ssm": "^3.49.0"
       },
       "devDependencies": {
@@ -137,6 +138,763 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.142.0.tgz",
+      "integrity": "sha512-Lc6JnPb+pAlGaX1qrO8Dmll8Zg5l1wIw7ZfxXfweNWvP5fny8cfOqho0DWAoZ8aQb8O/k9raXCdqSzj38uaR5w==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.142.0",
+        "@aws-sdk/config-resolver": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.142.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
+        "@aws-sdk/hash-node": "3.127.0",
+        "@aws-sdk/invalid-dependency": "3.127.0",
+        "@aws-sdk/middleware-content-length": "3.127.0",
+        "@aws-sdk/middleware-host-header": "3.127.0",
+        "@aws-sdk/middleware-logger": "3.127.0",
+        "@aws-sdk/middleware-recursion-detection": "3.127.0",
+        "@aws-sdk/middleware-retry": "3.127.0",
+        "@aws-sdk/middleware-serde": "3.127.0",
+        "@aws-sdk/middleware-signing": "3.130.0",
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/middleware-user-agent": "3.127.0",
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/node-http-handler": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/url-parser": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+        "@aws-sdk/util-defaults-mode-node": "3.142.0",
+        "@aws-sdk/util-user-agent-browser": "3.127.0",
+        "@aws-sdk/util-user-agent-node": "3.127.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "@aws-sdk/util-waiter": "3.127.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
+      "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sso": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.142.0.tgz",
+      "integrity": "sha512-Pewcpxq+wqcbB3t3s6KImBUUf+qqBNqMfd2wgQ3PdpYBjlNzrWYLHAnIT1vhIFjOGJXDi/qwF8FX7qbWNUB7Lg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.130.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
+        "@aws-sdk/hash-node": "3.127.0",
+        "@aws-sdk/invalid-dependency": "3.127.0",
+        "@aws-sdk/middleware-content-length": "3.127.0",
+        "@aws-sdk/middleware-host-header": "3.127.0",
+        "@aws-sdk/middleware-logger": "3.127.0",
+        "@aws-sdk/middleware-recursion-detection": "3.127.0",
+        "@aws-sdk/middleware-retry": "3.127.0",
+        "@aws-sdk/middleware-serde": "3.127.0",
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/middleware-user-agent": "3.127.0",
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/node-http-handler": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/url-parser": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+        "@aws-sdk/util-defaults-mode-node": "3.142.0",
+        "@aws-sdk/util-user-agent-browser": "3.127.0",
+        "@aws-sdk/util-user-agent-node": "3.127.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sts": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.142.0.tgz",
+      "integrity": "sha512-rOa1MTI1h3kTjlHkItAlXGHefM5sjsfw3muhNEhzrZBuhpOrLU8apbiG2rcJqB8m0prMoY39PuG+WquxN4ap6g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.142.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
+        "@aws-sdk/hash-node": "3.127.0",
+        "@aws-sdk/invalid-dependency": "3.127.0",
+        "@aws-sdk/middleware-content-length": "3.127.0",
+        "@aws-sdk/middleware-host-header": "3.127.0",
+        "@aws-sdk/middleware-logger": "3.127.0",
+        "@aws-sdk/middleware-recursion-detection": "3.127.0",
+        "@aws-sdk/middleware-retry": "3.127.0",
+        "@aws-sdk/middleware-sdk-sts": "3.130.0",
+        "@aws-sdk/middleware-serde": "3.127.0",
+        "@aws-sdk/middleware-signing": "3.130.0",
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/middleware-user-agent": "3.127.0",
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/node-http-handler": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/url-parser": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+        "@aws-sdk/util-defaults-mode-node": "3.142.0",
+        "@aws-sdk/util-user-agent-browser": "3.127.0",
+        "@aws-sdk/util-user-agent-node": "3.127.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
+      "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.130.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-config-provider": "3.109.0",
+        "@aws-sdk/util-middleware": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
+      "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
+      "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/url-parser": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.142.0.tgz",
+      "integrity": "sha512-joMJTxUTNmxURnVmmd7XhtwOwijMjh7z09V8o2EHQMk+ak+rhaRgqb2kTA2nO0J3SRxdO5z5SKkyQgW0d1fY9g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.127.0",
+        "@aws-sdk/credential-provider-imds": "3.127.0",
+        "@aws-sdk/credential-provider-sso": "3.142.0",
+        "@aws-sdk/credential-provider-web-identity": "3.127.0",
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/shared-ini-file-loader": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.142.0.tgz",
+      "integrity": "sha512-JkhCKNkEhCS2vgD/qg5hJPatupNLObqts9FXiDia5CF6w8YcHLH+mWSvhUMCUGkunAOvFHDkQL1uPXfoQuJvPg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.127.0",
+        "@aws-sdk/credential-provider-imds": "3.127.0",
+        "@aws-sdk/credential-provider-ini": "3.142.0",
+        "@aws-sdk/credential-provider-process": "3.127.0",
+        "@aws-sdk/credential-provider-sso": "3.142.0",
+        "@aws-sdk/credential-provider-web-identity": "3.127.0",
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/shared-ini-file-loader": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
+      "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/shared-ini-file-loader": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.142.0.tgz",
+      "integrity": "sha512-jJvp/A5xrikaeL0DhjhQTvUc0+eF0hN5Nbo+nxpnUOiOOkyqs329g65NI1TmLp/OzDcqQ/8p5vj2+7ufTGEOXQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.142.0",
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/shared-ini-file-loader": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
+      "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+      "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/querystring-builder": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/hash-node": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
+      "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
+      "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
+      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
+      "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
+      "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
+      "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
+      "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/service-error-classification": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-middleware": "3.127.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
+      "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.130.0",
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4": "3.130.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
+      "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
+      "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4": "3.130.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+      "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
+      "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
+      "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/shared-ini-file-loader": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
+      "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/querystring-builder": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/property-provider": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
+      "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+      "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+      "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
+      "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
+      "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
+      "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+      "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-hex-encoding": "3.109.0",
+        "@aws-sdk/util-middleware": "3.127.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+      "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/types": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/url-parser": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
+      "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+      "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
+      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
+      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
+      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
+      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
+      "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
+      "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
+      "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.130.0",
+        "@aws-sdk/credential-provider-imds": "3.127.0",
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/property-provider": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+      "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
+      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
+      "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
+      "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+      "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
+      "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.127.0.tgz",
+      "integrity": "sha512-E5qrRpBJS8dmClqSDW1pWVMKzCG/mxabG6jVUtlW/WLHnl/znxGaOQc6tnnwKik0nEq/4DpT9fEfPUz9JiLrkw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ssm": {
       "version": "3.49.0",
       "license": "Apache-2.0",
@@ -179,13 +937,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ssm/node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -465,6 +1216,39 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
+      "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+      "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+      "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-retry": {
       "version": "3.49.0",
       "license": "Apache-2.0",
@@ -477,13 +1261,6 @@
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -794,6 +1571,17 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+      "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-uri-escape": {
       "version": "3.49.0",
       "license": "Apache-2.0",
@@ -921,6 +1709,14 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "license": "0BSD"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     }
   },
   "dependencies": {
@@ -1038,6 +1834,622 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/client-cloudwatch": {
+      "version": "3.142.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.142.0.tgz",
+      "integrity": "sha512-Lc6JnPb+pAlGaX1qrO8Dmll8Zg5l1wIw7ZfxXfweNWvP5fny8cfOqho0DWAoZ8aQb8O/k9raXCdqSzj38uaR5w==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.142.0",
+        "@aws-sdk/config-resolver": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.142.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
+        "@aws-sdk/hash-node": "3.127.0",
+        "@aws-sdk/invalid-dependency": "3.127.0",
+        "@aws-sdk/middleware-content-length": "3.127.0",
+        "@aws-sdk/middleware-host-header": "3.127.0",
+        "@aws-sdk/middleware-logger": "3.127.0",
+        "@aws-sdk/middleware-recursion-detection": "3.127.0",
+        "@aws-sdk/middleware-retry": "3.127.0",
+        "@aws-sdk/middleware-serde": "3.127.0",
+        "@aws-sdk/middleware-signing": "3.130.0",
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/middleware-user-agent": "3.127.0",
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/node-http-handler": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/smithy-client": "3.142.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/url-parser": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+        "@aws-sdk/util-defaults-mode-node": "3.142.0",
+        "@aws-sdk/util-user-agent-browser": "3.127.0",
+        "@aws-sdk/util-user-agent-node": "3.127.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "@aws-sdk/util-waiter": "3.127.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
+          "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.142.0.tgz",
+          "integrity": "sha512-Pewcpxq+wqcbB3t3s6KImBUUf+qqBNqMfd2wgQ3PdpYBjlNzrWYLHAnIT1vhIFjOGJXDi/qwF8FX7qbWNUB7Lg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/fetch-http-handler": "3.131.0",
+            "@aws-sdk/hash-node": "3.127.0",
+            "@aws-sdk/invalid-dependency": "3.127.0",
+            "@aws-sdk/middleware-content-length": "3.127.0",
+            "@aws-sdk/middleware-host-header": "3.127.0",
+            "@aws-sdk/middleware-logger": "3.127.0",
+            "@aws-sdk/middleware-recursion-detection": "3.127.0",
+            "@aws-sdk/middleware-retry": "3.127.0",
+            "@aws-sdk/middleware-serde": "3.127.0",
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/middleware-user-agent": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/node-http-handler": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/smithy-client": "3.142.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+            "@aws-sdk/util-defaults-mode-node": "3.142.0",
+            "@aws-sdk/util-user-agent-browser": "3.127.0",
+            "@aws-sdk/util-user-agent-node": "3.127.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.142.0.tgz",
+          "integrity": "sha512-rOa1MTI1h3kTjlHkItAlXGHefM5sjsfw3muhNEhzrZBuhpOrLU8apbiG2rcJqB8m0prMoY39PuG+WquxN4ap6g==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/credential-provider-node": "3.142.0",
+            "@aws-sdk/fetch-http-handler": "3.131.0",
+            "@aws-sdk/hash-node": "3.127.0",
+            "@aws-sdk/invalid-dependency": "3.127.0",
+            "@aws-sdk/middleware-content-length": "3.127.0",
+            "@aws-sdk/middleware-host-header": "3.127.0",
+            "@aws-sdk/middleware-logger": "3.127.0",
+            "@aws-sdk/middleware-recursion-detection": "3.127.0",
+            "@aws-sdk/middleware-retry": "3.127.0",
+            "@aws-sdk/middleware-sdk-sts": "3.130.0",
+            "@aws-sdk/middleware-serde": "3.127.0",
+            "@aws-sdk/middleware-signing": "3.130.0",
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/middleware-user-agent": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/node-http-handler": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/smithy-client": "3.142.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.142.0",
+            "@aws-sdk/util-defaults-mode-node": "3.142.0",
+            "@aws-sdk/util-user-agent-browser": "3.127.0",
+            "@aws-sdk/util-user-agent-node": "3.127.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
+          "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-config-provider": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
+          "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
+          "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.142.0.tgz",
+          "integrity": "sha512-joMJTxUTNmxURnVmmd7XhtwOwijMjh7z09V8o2EHQMk+ak+rhaRgqb2kTA2nO0J3SRxdO5z5SKkyQgW0d1fY9g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.127.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/credential-provider-sso": "3.142.0",
+            "@aws-sdk/credential-provider-web-identity": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.142.0.tgz",
+          "integrity": "sha512-JkhCKNkEhCS2vgD/qg5hJPatupNLObqts9FXiDia5CF6w8YcHLH+mWSvhUMCUGkunAOvFHDkQL1uPXfoQuJvPg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.127.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/credential-provider-ini": "3.142.0",
+            "@aws-sdk/credential-provider-process": "3.127.0",
+            "@aws-sdk/credential-provider-sso": "3.142.0",
+            "@aws-sdk/credential-provider-web-identity": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
+          "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.142.0.tgz",
+          "integrity": "sha512-jJvp/A5xrikaeL0DhjhQTvUc0+eF0hN5Nbo+nxpnUOiOOkyqs329g65NI1TmLp/OzDcqQ/8p5vj2+7ufTGEOXQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.142.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
+          "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+          "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
+          "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
+          "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
+          "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
+          "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
+          "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
+          "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
+          "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/service-error-classification": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
+          "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.130.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
+          "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
+          "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
+          "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
+          "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
+          "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
+          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+          "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
+          "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
+          "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
+          "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+          "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.55.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-hex-encoding": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.142.0.tgz",
+          "integrity": "sha512-G38YWTfSFZb5cOH6IwLct530Uy8pnmJvJFeC1pd1nkKD4PRZb+bI2w4xXSX+znYdLA71RYK620OtVKJlB44PtA==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
+          "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+          "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
+          "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
+          "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
+          "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
+          "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
+          "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.142.0.tgz",
+          "integrity": "sha512-vVB/CrodMmIfv4v54MyBlKO0sQSI/+Mvs4g5gMyVjmT4a+1gnktJQ9R6ZHQ2/ErGewcra6eH9MU5T0r1kYe0+w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.142.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.142.0.tgz",
+          "integrity": "sha512-13d5RZLO13EDwll3COUq3D4KVsqM63kdf+YjG5mzXR1eXo6GVjghfQfiy0MYM6YbAjTfJxZQkc0nFgWLU8jdyg==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.55.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
+          "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
+          "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
+          "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+          "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
+          "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.127.0.tgz",
+          "integrity": "sha512-E5qrRpBJS8dmClqSDW1pWVMKzCG/mxabG6jVUtlW/WLHnl/znxGaOQc6tnnwKik0nEq/4DpT9fEfPUz9JiLrkw==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
     "@aws-sdk/client-ssm": {
       "version": "3.49.0",
       "requires": {
@@ -1076,11 +2488,6 @@
         "@aws-sdk/util-waiter": "3.49.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2"
-        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -1298,6 +2705,32 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
+      "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og=="
+        }
+      }
+    },
     "@aws-sdk/middleware-retry": {
       "version": "3.49.0",
       "requires": {
@@ -1306,11 +2739,6 @@
         "@aws-sdk/types": "3.49.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2"
-        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -1518,6 +2946,14 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/util-middleware": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+      "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/util-uri-escape": {
       "version": "3.49.0",
       "requires": {
@@ -1601,6 +3037,11 @@
     },
     "tslib": {
       "version": "2.3.1"
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     }
   }
 }

--- a/lambdas/agent-scaler/package.json
+++ b/lambdas/agent-scaler/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-auto-scaling": "^3.49.0",
+    "@aws-sdk/client-cloudwatch": "^3.49.0",
     "@aws-sdk/client-ssm": "^3.49.0"
   },
   "devDependencies": {

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -226,6 +226,11 @@ class AwsSemaphoreAgentStack extends Stack {
           resources: [
             `arn:aws:kms:*:*:key/${tokenKmsKey}`
           ]
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["cloudwatch:PutMetricData"],
+          resources: ["*"]
         })
       ]
     });

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -540,6 +540,11 @@ describe("scaler lambda", () => {
             Action: "kms:Decrypt",
             Effect: "Allow",
             Resource: "arn:aws:kms:*:*:key/dummy-kms-key-id"
+          },
+          {
+            Action: "cloudwatch:PutMetricData",
+            Effect: "Allow",
+            Resource: "*"
           }
         ],
         Version: Match.anyValue()


### PR DESCRIPTION
Currently, no metrics are published to CloudWatch, which makes it hard to monitor usage. This PR changes the scaler lambda to publish the occupancy for the stack to CloudWatch. The metric published is:
- Name: `JobCount`
- Dimensions (tags): the stack name and the job state (queued, running)

### Example chart

![Screen Shot 2022-08-03 at 13 05 16](https://user-images.githubusercontent.com/12387728/182657732-6461a67f-8c27-4d2a-b8b2-ad5df37bf379.png)
