### PR TITLE
fix: pin Erlang version

### DIFF
--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -16,4 +16,4 @@
   when: install_erlang | bool
   apt:
     pkg:
-      - erlang
+      - erlang-base=1:24.3.3-1


### PR DESCRIPTION
If not specified, Erlang/OTP 25 is installed, which came out recently. The when CLI does not work with that version, so we pin the version of the Erlang runtime here.