### PR TITLE
feat: add SEMAPHORE_AGENT_ASG_METRICS

### DIFF
--- a/lib/argument-store.js
+++ b/lib/argument-store.js
@@ -13,6 +13,7 @@ class ArgumentStore {
     "SEMAPHORE_AGENT_ASG_MIN_SIZE": "0",
     "SEMAPHORE_AGENT_ASG_MAX_SIZE": "1",
     "SEMAPHORE_AGENT_ASG_DESIRED": "",
+    "SEMAPHORE_AGENT_ASG_METRICS": "",
     "SEMAPHORE_AGENT_DISCONNECT_AFTER_JOB": "true",
     "SEMAPHORE_AGENT_DISCONNECT_AFTER_IDLE_TIMEOUT": "300",
     "SEMAPHORE_AGENT_OS": "ubuntu-focal",
@@ -92,6 +93,13 @@ class ArgumentStore {
 
   get(name) {
     return this.arguments[name];
+  }
+
+  getAsList(name) {
+    return this.get(name)
+      .split(",")
+      .map(item => item.trim())
+      .filter(item => item != "");
   }
 
   set(name, value) {

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -178,9 +178,7 @@ class AwsSemaphoreAgentStack extends Stack {
     ];
 
     if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES")) {
-      this.argumentStore.get("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES")
-        .split(",")
-        .map(policyName => policyName.trim())
+      this.argumentStore.getAsList("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES")
         .map((policyName, index) => ManagedPolicy.fromManagedPolicyName(this, `customPolicy${index}`, policyName))
         .forEach(policy => managedPolicies.push(policy));
     }
@@ -359,13 +357,22 @@ class AwsSemaphoreAgentStack extends Stack {
       autoScalingGroup.desiredCapacity = desiredCapacity;
     }
 
+    // Available metrics can be found here:
+    // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_autoscaling.CfnAutoScalingGroup.MetricsCollectionProperty.html
+    const asgMetrics = this.argumentStore.getAsList("SEMAPHORE_AGENT_ASG_METRICS")
+    if (asgMetrics.length > 0) {
+      autoScalingGroup.metricsCollection = [
+        {
+          granularity: "1Minute",
+          metrics: asgMetrics
+        }
+      ]
+    }
+
     if (this.argumentStore.isEmpty("SEMAPHORE_AGENT_VPC_ID")) {
       autoScalingGroup.availabilityZones = Stack.of(this).availabilityZones;
     } else {
-      const subnets = this.argumentStore
-        .get("SEMAPHORE_AGENT_SUBNETS")
-        .split(",")
-        .filter(subnet => subnet != "");
+      const subnets = this.argumentStore.getAsList("SEMAPHORE_AGENT_SUBNETS");
       autoScalingGroup.vpcZoneIdentifier = subnets
     }
 

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -444,6 +444,31 @@ describe("auto scaling group", () => {
     });
   })
 
+  test("metrics are not collected", () => {
+    const template = createTemplate(basicArgumentStore());
+    template.hasResourceProperties("AWS::AutoScaling::AutoScalingGroup", {
+      MetricsCollection: Match.absent()
+    });
+  })
+
+  test("metrics are collected", () => {
+    const argumentStore = basicArgumentStore();
+    argumentStore.set("SEMAPHORE_AGENT_ASG_METRICS", "GroupDesiredCapacity,GroupInServiceInstances,GroupPendingInstances")
+    const template = createTemplate(argumentStore);
+    template.hasResourceProperties("AWS::AutoScaling::AutoScalingGroup", {
+      MetricsCollection: [
+        {
+          Granularity: "1Minute",
+          Metrics: [
+            "GroupDesiredCapacity",
+            "GroupInServiceInstances",
+            "GroupPendingInstances"
+          ]
+        }
+      ]
+    });
+  })
+
   test("tags are used", () => {
     const template = createTemplate(basicArgumentStore());
     template.hasResourceProperties("AWS::AutoScaling::AutoScalingGroup", {


### PR DESCRIPTION
Currently, no ASG metrics are collected. This PR adds a new argument, `SEMAPHORE_AGENT_ASG_METRICS`, which receives a comma-separated list of ASG metrics to collect. The available metrics can be found [here](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_autoscaling.CfnAutoScalingGroup.MetricsCollectionProperty.html).