### PR TITLE
allow overriding SEMAPHORE_AGENT_STACK_CONFIG values with env vars

### DIFF
--- a/lib/argument-store.js
+++ b/lib/argument-store.js
@@ -48,7 +48,7 @@ class ArgumentStore {
 
     console.log(`==> Using config file at ${configFilePath} ...`);
     const config = JSON.parse(fs.readFileSync(configFilePath, { encoding: 'utf-8' }))
-    return ArgumentStore.fromMap(config);
+    return ArgumentStore.fromMap(Object.assign({}, config, process.env));
   }
 
   static fromMap(params) {


### PR DESCRIPTION
Currently, the stack configuration can be provided either as a JSON file via SEMAPHORE_AGENT_STACK_CONFIG or as environment variables, but you can't combine the two. This changes it so that a user can provide a JSON file and then also provide environment variables. If there are duplicates, the environment variables take precedence. 

For my use case, I'd like to supply most of my parameters via the JSON file, but I'd also like to pass the `SEMAPHORE_AGENT_AMI` environment variable, so I don't have to store my AMI ID in source code.


### Testing
I set the `SEMAPHORE_AGENT_AMI` and `SEMAPHORE_AGENT_STACK_CONFIG` environment variables then ran a CDK diff and saw:
```
Resources
 └─ [~] ImageId (requires replacement)
     ├─ [-] ami-****
     └─ [+] ami-****
```