### PR TITLE
feat: use new /metrics endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "aws-cdk": "^2.33.0",
         "aws-cdk-lib": "^2.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },


### PR DESCRIPTION
This PR updates the scaler lambda to use the new `/metrics` endpoint. The endpoint exposes the same numbers as the `/occupancy` endpoint + the number of agents per state:

```json
{
  "jobs": {
    "queued": 2,
    "running": 8
  },
  "agents": {
    "idle": 12,
    "occupied": 4
  }
}
```

A new `AgentCount` metric is pushed to CloudWatch, alongside the current `JobCount` one:

<img width="1531" alt="Screen Shot 2022-09-27 at 16 21 13" src="https://user-images.githubusercontent.com/12387728/192617709-46ab2d95-b79d-4fa8-a4a9-c1403a362fd8.png">

The `/occupancy` endpoint is now deprecated and will be removed in the future.