### PR TITLE
feat: use launch templates

### DIFF
--- a/execution-policy.json
+++ b/execution-policy.json
@@ -14,7 +14,15 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
-        "ec2:CreateTags"
+        "ec2:CreateTags",
+        "ec2:CreateLaunchTemplate",
+        "ec2:CreateLaunchTemplateVersion",
+        "ec2:DeleteLaunchTemplate",
+        "ec2:DeleteLaunchTemplateVersions",
+        "ec2:DescribeLaunchTemplateVersions",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:GetLaunchTemplateData",
+        "ec2:ModifyLaunchTemplate"
       ],
       "Resource": "*"
     },

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -10,9 +10,9 @@ const { RetentionDays } = require("aws-cdk-lib/aws-logs");
 const { StringParameter, ParameterTier } = require("aws-cdk-lib/aws-ssm");
 const { Function, Runtime, AssetCode } = require("aws-cdk-lib/aws-lambda");
 const { Policy, PolicyStatement, Role, ServicePrincipal, ManagedPolicy, CfnInstanceProfile, Effect } = require("aws-cdk-lib/aws-iam");
-const { CfnAutoScalingGroup, CfnLaunchConfiguration } = require("aws-cdk-lib/aws-autoscaling");
+const { CfnAutoScalingGroup } = require("aws-cdk-lib/aws-autoscaling");
 const { Alias } = require("aws-cdk-lib/aws-kms");
-const { SecurityGroup, Vpc, Peer, Port, LookupMachineImage, UserData } = require("aws-cdk-lib/aws-ec2");
+const { SecurityGroup, Vpc, Peer, Port, LookupMachineImage, UserData, CfnLaunchTemplate, LaunchTemplate, BlockDeviceVolume, EbsDeviceVolumeType, MachineImage } = require("aws-cdk-lib/aws-ec2");
 
 class AwsSemaphoreAgentStack extends Stack {
   constructor(scope, id, props) {
@@ -38,10 +38,10 @@ class AwsSemaphoreAgentStack extends Stack {
      * environment variable.
      */
     let ssmParameter = this.createSSMParameter();
-    let iamInstanceProfile = this.createIamInstanceProfile(defaultSSMKey);
-    let securityGroups = this.createSecurityGroups();
-    let launchConfiguration = this.createLaunchConfiguration(ssmParameter, iamInstanceProfile, securityGroups);
-    let autoScalingGroup = this.createAutoScalingGroup(launchConfiguration);
+    let instanceRole = this.createIamInstanceRole(defaultSSMKey);
+    let securityGroup = this.createSecurityGroup();
+    let launchTemplate = this.createLaunchTemplate(ssmParameter, instanceRole, securityGroup);
+    let autoScalingGroup = this.createAutoScalingGroup(launchTemplate);
     this.createAzRebalanceSuspender(autoScalingGroup);
 
     if (this.argumentStore.get("SEMAPHORE_AGENT_USE_DYNAMIC_SCALING") == "true") {
@@ -84,7 +84,7 @@ class AwsSemaphoreAgentStack extends Stack {
     });
   }
 
-  createIamInstanceProfile(defaultAWSSSMKey) {
+  createIamInstanceRole(defaultAWSSSMKey) {
     let tokenKmsKey = this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_KMS_KEY") || defaultAWSSSMKey.keyId
     let policy = new Policy(this, 'instanceProfilePolicy', {
       policyName: `${this.stackName}-instance-profile-policy`,
@@ -150,17 +150,7 @@ class AwsSemaphoreAgentStack extends Stack {
     });
 
     policy.attachToRole(role);
-
-    let instanceProfileDeps = new DependencyGroup();
-    instanceProfileDeps.add(role);
-
-    let iamInstanceProfile = new CfnInstanceProfile(this, 'instanceProfile', {
-      roles: [role.roleName],
-      path: '/'
-    })
-
-    iamInstanceProfile.node.addDependency(instanceProfileDeps);
-    return iamInstanceProfile;
+    return role;
   }
 
   getInstanceProfileRoleManagedPolicies() {
@@ -177,10 +167,10 @@ class AwsSemaphoreAgentStack extends Stack {
     return managedPolicies;
   }
 
-  createSecurityGroups() {
+  createSecurityGroup() {
     let securityGroupId = this.argumentStore.get("SEMAPHORE_AGENT_SECURITY_GROUP_ID");
     if (securityGroupId) {
-      return [securityGroupId]
+      return SecurityGroup.fromLookupById(this, "securityGroup", securityGroupId)
     }
 
     const vpcLookupOptions = this.argumentStore.isEmpty("SEMAPHORE_AGENT_VPC_ID") ?
@@ -195,7 +185,7 @@ class AwsSemaphoreAgentStack extends Stack {
       securityGroup.addIngressRule(Peer.anyIpv4(), Port.tcp(22), 'allow ssh access from anywhere');
     }
 
-    return [securityGroup.securityGroupId];
+    return securityGroup;
   }
 
   createScalerLambdaRole(defaultAWSSSMKey, autoScalingGroup) {
@@ -289,58 +279,70 @@ class AwsSemaphoreAgentStack extends Stack {
     return rule;
   }
 
-  createLaunchConfiguration(ssmParameter, iamInstanceProfile, securityGroups) {
-    const launchConfigDependencies = new DependencyGroup();
-    launchConfigDependencies.add(iamInstanceProfile);
-    launchConfigDependencies.add(ssmParameter);
+  createLaunchTemplate(ssmParameter, instanceRole, securityGroup) {
+    const launchTemplateDependencies = new DependencyGroup();
+    launchTemplateDependencies.add(instanceRole);
+    launchTemplateDependencies.add(ssmParameter);
 
-    let imageId = this.argumentStore.get("SEMAPHORE_AGENT_AMI")
-    if (!imageId) {
+    const keyName = this.argumentStore.get("SEMAPHORE_AGENT_KEY_NAME")
+    let launchTemplate = new LaunchTemplate(this, 'launchTemplate', {
+      instanceType: this.argumentStore.get("SEMAPHORE_AGENT_INSTANCE_TYPE"),
+      machineImage: this.findMachineImage(),
+      role: instanceRole,
+      userData: this.getUserData(),
+      blockDevices: this.createBlockDevices(),
+      securityGroup: securityGroup,
+      keyName: keyName != "" ? keyName : undefined
+    });
+
+    launchTemplate.node.addDependency(launchTemplateDependencies);
+    return launchTemplate;
+  }
+
+  findMachineImage() {
+    if (this.argumentStore.isEmpty("SEMAPHORE_AGENT_AMI")) {
       const os = this.argumentStore.get("SEMAPHORE_AGENT_OS");
       const arch = "x86_64";
-      const props = {
+      return new LookupMachineImage({
         architecture: arch,
         name: `semaphore-agent-v${packageInfo.version}-${os}-${arch}-${hash(os)}`,
         owners: [this.account]
+      })
+    }
+
+    return new LookupMachineImage({
+      name: "*",
+      filters: {
+        "image-id": [this.argumentStore.get("SEMAPHORE_AGENT_AMI")]
       }
+    })
+  }
 
-      const machineImage = new LookupMachineImage(props).getImage(this)
-      imageId = machineImage.imageId
+  createBlockDevices() {
+    if (this.argumentStore.isEmpty("SEMAPHORE_AGENT_VOLUME_NAME")) {
+      return undefined
     }
 
-    let launchConfig = new CfnLaunchConfiguration(this, 'launchConfiguration', {
-      imageId: imageId,
-      instanceType: this.argumentStore.get("SEMAPHORE_AGENT_INSTANCE_TYPE"),
-      iamInstanceProfile: iamInstanceProfile.attrArn,
-      securityGroups: securityGroups,
-      userData: Fn.base64(this.getUserData().render())
-    });
-
-    const keyName = this.argumentStore.get("SEMAPHORE_AGENT_KEY_NAME")
-    if (keyName) {
-      launchConfig.keyName = keyName;
-    }
-
-    const volumeName = this.argumentStore.get("SEMAPHORE_AGENT_VOLUME_NAME")
-    if (volumeName) {
-      launchConfig.blockDeviceMappings = [
-        {
-          deviceName: volumeName,
-          ebs: {
+    return [
+      {
+        deviceName: this.argumentStore.get("SEMAPHORE_AGENT_VOLUME_NAME"),
+        volume: {
+          ebsDevice: {
             volumeType: this.argumentStore.get("SEMAPHORE_AGENT_VOLUME_TYPE"),
             volumeSize: this.argumentStore.getAsNumber("SEMAPHORE_AGENT_VOLUME_SIZE")
           }
         }
-      ]
-    }
-
-    launchConfig.node.addDependency(launchConfigDependencies);
-    return launchConfig;
+      }
+    ]
   }
 
-  createAutoScalingGroup(launchConfiguration) {
+  createAutoScalingGroup(launchTemplate) {
+    const cfnLaunchTemplate = launchTemplate.node.defaultChild
     let autoScalingGroup = new CfnAutoScalingGroup(this, 'autoScalingGroup', {
-      launchConfigurationName: launchConfiguration.ref,
+      launchTemplate: {
+        launchTemplateId: cfnLaunchTemplate.ref,
+        version: cfnLaunchTemplate.attrLatestVersionNumber
+      },
       minSize: this.argumentStore.get("SEMAPHORE_AGENT_ASG_MIN_SIZE"),
       maxSize: this.argumentStore.get("SEMAPHORE_AGENT_ASG_MAX_SIZE"),
       cooldown: "60",


### PR DESCRIPTION
Launch configurations are an old thing, so they lack a lot of features. To support Mac, spot instances and possibly other things, we need to use launch templates.