### PR TITLE
fix: delete old AMIs based on tag

### DIFF
--- a/ci/delete-old-images.sh
+++ b/ci/delete-old-images.sh
@@ -3,6 +3,7 @@
 set -e
 set -o pipefail
 
+latest_tag=$(git describe --tags --abbrev=0)
 image_ids=($(aws ec2 describe-images \
   --filters "Name=name,Values=semaphore-agent-*" "Name=is-public,Values=false" \
   --query 'Images[*].ImageId' \
@@ -10,13 +11,24 @@ image_ids=($(aws ec2 describe-images \
 ))
 
 for image_id in "${image_ids[@]}"; do
+  image_name=$(aws ec2 describe-images \
+    --image-ids "${image_id}" \
+    --query 'Images[*].Name' \
+    --output text
+  )
+
+  if [[ "${image_name}" == *"${latest_tag}"* ]]; then
+    echo "Image ${image_name} is for latest tag - skipping."
+    continue
+  fi
+
   snapshot_id=$(aws ec2 describe-images \
     --image-ids "${image_id}" \
     --query 'Images[*].BlockDeviceMappings[*].Ebs.SnapshotId' \
     --output text
   )
 
-  echo "De-registering image '${image_id}'..."
+  echo "De-registering image '${image_id}' (${image_name})..."
   aws ec2 deregister-image --image-id ${image_id}
 
   if [[ -n ${snapshot_id} ]]; then


### PR DESCRIPTION
Initially, this script was created to delete old private images. We don't manage public images, so it is only helpful to delete old AMIs. The only AMIs that are not deleted are the ones created for the latest tag.