### PR TITLE
set licenseConfigurationArn on a LaunchTemplate for macOS

### DIFF
--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -347,6 +347,9 @@ class AwsSemaphoreAgentStack extends Stack {
       launchTemplate.node.defaultChild.launchTemplateData.placement = {
         hostResourceGroupArn: hostResourceGroup.attrArn
       }
+      launchTemplate.node.defaultChild.launchTemplateData.licenseSpecifications = [{
+        licenseConfigurationArn: this.argumentStore.get("SEMAPHORE_AGENT_LICENSE_CONFIGURATION_ARN")
+      }]
     }
 
     launchTemplate.node.addDependency(launchTemplateDependencies);


### PR DESCRIPTION
This sets the `licenseConfigurationArn` field on the `LaunchTemplate` for macOS pools.

Prior to this change I was seeing the ASG fail to create with

```
AwsSemaphoreAgentStack/autoScalingGroup (autoScalingGroup) You must use a valid fully-formed launch template. One or more licenses need to be specified for a valid Server Manageability call.
```

Why the license config needs to be referenced by both the launch template and the host resource group is a mystery to me, but this works.