### PR TITLE
add some permissions to the execution policy

### DIFF
--- a/execution-policy.json
+++ b/execution-policy.json
@@ -15,6 +15,7 @@
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
         "ec2:CreateTags",
+        "ec2:DeleteTags",
         "ec2:CreateLaunchTemplate",
         "ec2:CreateLaunchTemplateVersion",
         "ec2:DeleteLaunchTemplate",
@@ -99,7 +100,8 @@
         "lambda:InvokeFunction",
         "lambda:UpdateFunctionCode",
         "lambda:UpdateFunctionConfiguration",
-        "lambda:TagResource"
+        "lambda:TagResource",
+        "lambda:UntagResource"
       ],
       "Resource": "arn:aws:lambda:*:*:function:*"
     },
@@ -194,6 +196,7 @@
         "autoscaling:SetInstanceProtection",
         "autoscaling:CreateAutoScalingGroup",
         "autoscaling:EnableMetricsCollection",
+        "autoscaling:DisableMetricsCollection",
         "autoscaling:UpdateAutoScalingGroup",
         "autoscaling:DeleteAutoScalingGroup",
         "autoscaling:PutScalingPolicy",
@@ -207,7 +210,9 @@
         "autoscaling:AttachInstances",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:CreateLaunchConfiguration",
-        "autoscaling:DeleteLaunchConfiguration"
+        "autoscaling:DeleteLaunchConfiguration",
+        "autoscaling:CreateOrUpdateTags",
+        "autoscaling:DeleteTags"
       ],
       "Resource": "*"
     },

--- a/execution-policy.json
+++ b/execution-policy.json
@@ -240,20 +240,6 @@
       "Resource": "arn:aws:s3:::cdk*"
     },
     {
-      "Sid": "LaunchTemplateAccess",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateLaunchTemplate",
-        "ec2:CreateLaunchTemplateVersion",
-        "ec2:DeleteLaunchTemplate",
-        "ec2:DeleteLaunchTemplateVersions",
-        "ec2:DescribeLaunchTemplateVersions",
-        "ec2:DescribeLaunchTemplates",
-        "ec2:ModifyLaunchTemplate"
-      ],
-      "Resource": "*"
-    },
-    {
       "Sid": "ResourceGroupAccess",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
This adds a few new permissions to the execution policy. These permissions are not overly critical. 
* The delete permissions I ended up needing when failing to update stacks and rolling back. 
* The `autoscaling:CreateOrUpdateTags` was needed for tagging ASGs. 
* The removal of the `LaunchTemplateAccess` block was necessary because the policy hit the character limit when adding the other permissions. Conveniently, the permissions in the `LaunchTemplateAccess` block were replicated earlier in the policy: https://github.com/renderedtext/agent-aws-stack/blob/master/execution-policy.json#L18-L25.