### PR TITLE
fix: configure macOS shutdown hook

### DIFF
--- a/packer/macos/files/terminate-instance.sh
+++ b/packer/macos/files/terminate-instance.sh
@@ -1,0 +1,29 @@
+# Shutdown hook is not executed in a login shell,
+# and launchD has no default built-in mechanism for loading environments
+# like systemD's environment generators, so we need to set the PATH
+# environment variable (and any other variables we might expect) here.
+export PATH=/usr/local/bin:$PATH
+
+token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
+instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
+region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
+
+# We unset all AWS related variables to make sure the instance profile is always used.
+# Before, we were using a specific AWS CLI profile that activates the instance profile,
+# but that didn't work if people messed up the ~/.aws/config file.
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN
+rm -rf $HOME/.aws/credentials
+
+if [[ $SEMAPHORE_AGENT_SHUTDOWN_REASON == "IDLE" ]]; then
+  aws autoscaling terminate-instance-in-auto-scaling-group \
+    --region "$region" \
+    --instance-id "$instance_id" \
+    --should-decrement-desired-capacity
+else
+  aws autoscaling terminate-instance-in-auto-scaling-group \
+    --region "$region" \
+    --instance-id "$instance_id" \
+    --no-should-decrement-desired-capacity
+fi

--- a/packer/macos/macos.pkr.hcl
+++ b/packer/macos/macos.pkr.hcl
@@ -95,7 +95,8 @@ build {
     destination = "/tmp/"
     sources = [
       "files/amazon-cloudwatch-agent.json",
-      "files/start-agent.sh"
+      "files/start-agent.sh",
+      "files/terminate-instance.sh"
     ]
   }
 

--- a/packer/macos/scripts/provision-ami.sh
+++ b/packer/macos/scripts/provision-ami.sh
@@ -76,12 +76,16 @@ if [[ ${ARCH} =~ "arm" || ${ARCH} == "aarch64" ]]; then
   AGENT_TARBALL=agent_Darwin_arm64.tar.gz
 fi
 
+# Create installation directory
 sudo mkdir -p /opt/semaphore/agent
-sudo chown $USER: /opt/semaphore/agent/
 cd /opt/semaphore/agent
-curl -L https://github.com/semaphoreci/agent/releases/download/$AGENT_VERSION/$AGENT_TARBALL -o agent.tar.gz
-tar xvf agent.tar.gz
-rm agent.tar.gz
+sudo curl -L https://github.com/semaphoreci/agent/releases/download/$AGENT_VERSION/$AGENT_TARBALL -o agent.tar.gz
+sudo tar xvf agent.tar.gz
+sudo rm agent.tar.gz
+
+# Create hooks directory
+sudo mkdir -p /opt/semaphore/agent/hooks
+sudo cp /tmp/terminate-instance.sh /opt/semaphore/agent/hooks/shutdown
 
 # Install Semaphore agent
 export SEMAPHORE_AGENT_INSTALLATION_USER=semaphore
@@ -89,6 +93,9 @@ export SEMAPHORE_TOOLBOX_VERSION=$TOOLBOX_VERSION
 export SEMAPHORE_AGENT_START=false
 export SEMAPHORE_REGISTRATION_TOKEN=DUMMY
 export SEMAPHORE_ORGANIZATION=DUMMY
+export SEMAPHORE_AGENT_SHUTDOWN_HOOK=/opt/semaphore/agent/hooks/shutdown
 sudo -E ./install.sh
 
-cp /tmp/start-agent.sh /opt/semaphore/agent/start.sh
+# Copy agent startup script and apply folder permissions
+sudo cp /tmp/start-agent.sh /opt/semaphore/agent/start.sh
+sudo chown -R semaphore: /opt/semaphore/agent


### PR DESCRIPTION
Adds a shutdown hook to terminate the instance when the agent shuts down.

The shutdown hook is executed in a non-login shell. Since LaunchD has no default [environment generator](https://www.freedesktop.org/software/systemd/man/environment.d.html) mechanism like systemD, we'd need to use the `launchctl setenv` or `launchctl config` commands for configuring it.

Since the only environment setup needed in that script is to include `/usr/local/bin` to the `PATH`, we do it in the script itself, for simplicity.