### PR TITLE
fix: improve SSH keys updater logs on errors

### DIFF
--- a/lambdas/ssh-keys-updater/app.js
+++ b/lambdas/ssh-keys-updater/app.js
@@ -12,17 +12,20 @@ function getGitHubSSHKeys() {
   return new Promise((resolve, reject) => {
     let data = '';
     https.request(options, response => {
-      if (response.statusCode !== 200) {
-        reject(`Request to get GitHub SSH keys got ${response.statusCode}`);
-        return;
-      }
-
       response.on('data', function (chunk) {
         data += chunk;
       });
 
       response.on('end', function () {
-        resolve(JSON.parse(data).ssh_keys);
+        if (response.statusCode !== 200) {
+          const errMessage = `Request to get GitHub SSH keys failed with ${response.statusCode}`
+          console.error(errMessage);
+          console.error(`Response: ${data}`);
+          console.error(`Headers: ${JSON.stringify(response.headers)}`);
+          reject(errMessage);
+        } else {
+          resolve(JSON.parse(data).ssh_keys);
+        }
       });
     })
     .on('error', error => reject(error))


### PR DESCRIPTION
The SSH keys updater lambda doesn't currently log anything helpful about the HTTP response when GitHub gives us a non-successful one. This makes it difficult to troubleshoot issues.

This pull request fixes that by logging the complete HTTP response and headers when that happens.