### PR TITLE
fix: fetch agent token on first scaler lambda tick only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "aws-cdk": "^2.58.0",
         "aws-cdk-lib": "^2.58.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },


### PR DESCRIPTION
There's no need to fetch the agent token on each tick. Fetching it on the first one is enough. If the token changes, it will be re-fetch on the next lambda run.