### PR TITLE
fix: include next tick duration on check

### DIFF
--- a/lambdas/agent-scaler/app.js
+++ b/lambdas/agent-scaler/app.js
@@ -271,6 +271,7 @@ exports.handler = async (event, context, callback) => {
    */
   const interval = 10;
   const timeout = epochSeconds() + 60;
+  const tickDuration = 5;
   let now = epochSeconds();
 
   try {
@@ -279,9 +280,11 @@ exports.handler = async (event, context, callback) => {
     while (true) {
       await tick(agentTypeToken, stackName, autoScalingClient, cloudwatchClient, semaphoreEndpoint);
 
-      // Check if we will hit the timeout before sleeping...
+      // Check if we will hit the timeout before sleeping.
+      // We include a worst-case scenario for the next tick duration (5s) here too,
+      // to avoid hitting the timeout while running the next tick.
       now = epochSeconds();
-      if ((now + interval) >= timeout) {
+      if ((now + interval + tickDuration) >= timeout) {
         break
       }
 


### PR DESCRIPTION
https://github.com/renderedtext/agent-aws-stack/pull/115 and https://github.com/renderedtext/agent-aws-stack/pull/117 solved the issue of the lambda timing out due to the SSM API being slow to respond. However, the lambda still seems to be timing out while running the last tick or because the check for stopping runs right before (milliseconds before) the 10s sleep. This pull request includes the next tick duration in the check too. That way, if the lambda doesn't have enough time for sleep + next tick (15s), we stop and let the next lambda run continue.