### PR TITLE
fix: decrease SSH keys lambda rate

### DIFF
--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -82,7 +82,7 @@ class DynamicSSHKeysUpdater extends Construct {
 
     const rule = new Rule(this, 'EventRule', {
       description: `Rule to dynamically invoke lambda function to check GitHub public SSH keys.`,
-      schedule: Schedule.expression('rate(1 hour)'),
+      schedule: Schedule.expression('rate(8 hours)'),
       targets: [new LambdaFunction(lambda)]
     });
 

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -82,7 +82,7 @@ class DynamicSSHKeysUpdater extends Construct {
 
     const rule = new Rule(this, 'EventRule', {
       description: `Rule to dynamically invoke lambda function to check GitHub public SSH keys.`,
-      schedule: Schedule.expression('rate(8 hours)'),
+      schedule: Schedule.expression('rate(1 day)'),
       targets: [new LambdaFunction(lambda)]
     });
 

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -689,7 +689,7 @@ describe("SSH keys updater lambda", () => {
     const template = createTemplate(basicArgumentStore());
     template.hasResourceProperties("AWS::Events::Rule", {
       Description: "Rule to dynamically invoke lambda function to check GitHub public SSH keys.",
-      ScheduleExpression: "rate(1 hour)",
+      ScheduleExpression: "rate(1 day)",
       State: "ENABLED",
       Targets: Match.anyValue()
     });


### PR DESCRIPTION
The GitHub SSH keys are updated very infrequently, so there's no reason for us to check on them hourly. Daily seems like a better schedule for it.