### PR TITLE
add lambda DeleteFunctionConcurrency and ListTags to execution policy

### DIFF
--- a/execution-policy.json
+++ b/execution-policy.json
@@ -104,7 +104,8 @@
         "lambda:UpdateFunctionCode",
         "lambda:UpdateFunctionConfiguration",
         "lambda:TagResource",
-        "lambda:UntagResource"
+        "lambda:UntagResource",
+        "lambda:ListTags"
       ],
       "Resource": "arn:aws:lambda:*:*:function:*"
     },

--- a/execution-policy.json
+++ b/execution-policy.json
@@ -93,6 +93,7 @@
       "Action": [
         "lambda:CreateFunction",
         "lambda:PutFunctionConcurrency",
+        "lambda:DeleteFunctionConcurrency",
         "lambda:PutFunctionEventInvokeConfig",
         "lambda:DeleteFunctionEventInvokeConfig",
         "lambda:GetFunction",


### PR DESCRIPTION
This adds the `lambda:DeleteFunctionConcurrency` and `lambda:ListTags` permissions to the execution policy. 

I tried to deploy my CDK stack update for 0.2.9 without including the changes to `exection-policy.json`. I ran into `is not authorized to perform: lambda:PutFunctionConcurrency on` during the CloudFormation stack update and subsequently `is not authorized to perform: lambda:DeleteFunctionConcurrency on` in the CloudFormation rollback. Obviously a miss on my part, but adding `lambda:DeleteFunctionConcurrency` will allow future rollbacks to work properly as necessary.

For the `lambda:ListTags`, I added this locally a while back, so I don't know the specific usage that requires it or what the error behavior is when this is missing. I am guessing it is used when deploying a Lambda with any set of tags associated with it.