### PR TITLE
fix: remove DeleteLogGroup permission from instance profile

### DIFF
--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -118,8 +118,11 @@ class AwsSemaphoreAgentStack extends Stack {
           effect: Effect.ALLOW,
           actions: [
             "logs:CreateLogGroup",
-            "logs:PutRetentionPolicy",
-            "logs:DeleteLogGroup"
+            "logs:CreateLogStream",
+            "logs:DescribeLogStreams",
+            "logs:DescribeLogGroups",
+            "logs:PutLogEvents",
+            "logs:PutRetentionPolicy"
           ],
           resources: [
             "arn:aws:logs:*:*:log-group:/semaphore/*"

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -196,8 +196,11 @@ describe("instance profile", () => {
           {
             Action: [
               "logs:CreateLogGroup",
-              "logs:PutRetentionPolicy",
-              "logs:DeleteLogGroup"
+              "logs:CreateLogStream",
+              "logs:DescribeLogStreams",
+              "logs:DescribeLogGroups",
+              "logs:PutLogEvents",
+              "logs:PutRetentionPolicy"
             ],
             Effect: "Allow",
             Resource: "arn:aws:logs:*:*:log-group:/semaphore/*"
@@ -244,8 +247,11 @@ describe("instance profile", () => {
           {
             Action: [
               "logs:CreateLogGroup",
-              "logs:PutRetentionPolicy",
-              "logs:DeleteLogGroup"
+              "logs:CreateLogStream",
+              "logs:DescribeLogStreams",
+              "logs:DescribeLogGroups",
+              "logs:PutLogEvents",
+              "logs:PutRetentionPolicy"
             ],
             Effect: "Allow",
             Resource: "arn:aws:logs:*:*:log-group:/semaphore/*"


### PR DESCRIPTION
AWS provides a custom policy called [`CloudWatchAgentServerPolicy`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/create-iam-roles-for-cloudwatch-agent.html), with the permissions needed for the CloudWatch agent. We should use the same permissions as that custom policy, which does not include the `logs:DeleteLogGroup` one.