### PR TITLE
fix: use poweroff on health check script

### DIFF
--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -12,7 +12,7 @@ const { Function, Runtime, AssetCode } = require("aws-cdk-lib/aws-lambda");
 const { Policy, PolicyStatement, Role, ServicePrincipal, ManagedPolicy, Effect } = require("aws-cdk-lib/aws-iam");
 const { CfnAutoScalingGroup } = require("aws-cdk-lib/aws-autoscaling");
 const { Alias } = require("aws-cdk-lib/aws-kms");
-const { SecurityGroup, Vpc, Peer, Port, LookupMachineImage, UserData, LaunchTemplate, SubnetType } = require("aws-cdk-lib/aws-ec2");
+const { SecurityGroup, Vpc, Peer, Port, LookupMachineImage, UserData, LaunchTemplate, SubnetType, InstanceInitiatedShutdownBehavior } = require("aws-cdk-lib/aws-ec2");
 const { CfnGroup } = require("aws-cdk-lib/aws-resourcegroups");
 
 class AwsSemaphoreAgentStack extends Stack {
@@ -319,6 +319,7 @@ class AwsSemaphoreAgentStack extends Stack {
       userData: this.getUserData(),
       blockDevices: this.createBlockDevices(),
       securityGroup: securityGroup,
+      instanceInitiatedShutdownBehavior: InstanceInitiatedShutdownBehavior.TERMINATE,
       keyName: keyName != "" ? keyName : undefined
     });
 

--- a/packer/linux/ansible/roles/agent/files/health-check.sh
+++ b/packer/linux/ansible/roles/agent/files/health-check.sh
@@ -1,24 +1,14 @@
 #!/bin/bash
 
-mark_as_unhealthy() {
-  local __token__=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
-  local __instance_id__=$(curl -H "X-aws-ec2-metadata-token: $__token__" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
-
-  # We unset all AWS related variables to make sure the instance profile is used for this.
-  unset AWS_ACCESS_KEY_ID
-  unset AWS_SECRET_ACCESS_KEY
-  unset AWS_SESSION_TOKEN
-  rm -rf $HOME/.aws/credentials
-
-  aws autoscaling set-instance-health \
-    --instance-id "${__instance_id__}" \
-    --health-status Unhealthy
-}
-
 procs=$(ps aux | grep "/opt/semaphore/agent/agent start" | grep -v grep)
 if [[ -z ${procs} ]]; then
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is not running - marking instance as unhealthy."
-  mark_as_unhealthy
+
+  # We shut down the instance using the OS here (instead of IMDS and autoscaling API),
+  # because this script will only be needed when the agent itself can't terminate the instance
+  # using IMDS and the autoscaling API. That can happen because the job messed up with the
+  # IMDS setup in the VM or some other weird behavior.
+  poweroff
 else
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is running."
 fi

--- a/packer/macos/files/health-check.sh
+++ b/packer/macos/files/health-check.sh
@@ -8,25 +8,15 @@ else
   export PATH=/usr/local/bin:$PATH
 fi
 
-mark_as_unhealthy() {
-  local __token__=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
-  local __instance_id__=$(curl -H "X-aws-ec2-metadata-token: $__token__" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
-
-  # We unset all AWS related variables to make sure the instance profile is used for this.
-  unset AWS_ACCESS_KEY_ID
-  unset AWS_SECRET_ACCESS_KEY
-  unset AWS_SESSION_TOKEN
-  rm -rf $HOME/.aws/credentials
-
-  aws autoscaling set-instance-health \
-    --instance-id "${__instance_id__}" \
-    --health-status Unhealthy
-}
-
 procs=$(ps aux | grep "/opt/semaphore/agent/agent start" | grep -v grep)
 if [[ -z ${procs} ]]; then
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is not running - marking instance as unhealthy."
-  mark_as_unhealthy
+
+  # We shut down the instance using the OS here (instead of IMDS and autoscaling API),
+  # because this script will only be needed when the agent itself can't terminate the instance
+  # using IMDS and the autoscaling API. That can happen because the job messed up with the
+  # IMDS setup in the VM or some other weird behavior.
+  poweroff
 else
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is running."
 fi

--- a/packer/windows/scripts/health-check.ps1
+++ b/packer/windows/scripts/health-check.ps1
@@ -1,21 +1,3 @@
-function Set-InstanceHealth {
-  $Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '60'} http://169.254.169.254/latest/api/token).content
-  $instance_id = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
-
-  # We unset all AWS related variables to make sure the instance profile is always used.
-  $env:AWS_ACCESS_KEY_ID = ""
-  $env:AWS_SECRET_ACCESS_KEY = ""
-  $env:AWS_SESSION_TOKEN = ""
-
-  if (Test-Path "$HOME\.aws\credentials") {
-    Remove-Item -Recurse -Force -Path "$HOME\.aws\credentials"
-  }
-
-  aws autoscaling set-instance-health `
-    --instance-id "$instance_id" `
-    --health-status Unhealthy
-}
-
 $proc = Get-Process | Where {$_.Path -Like "C:\semaphore-agent\agent.exe"}
 if ($proc) {
   Add-Content `
@@ -25,5 +7,10 @@ if ($proc) {
   Add-Content `
     -Path C:\semaphore-agent\health-check.log `
     -Value "[$(Get-Date -Format 'dd/MM/yyyy HH:mm')] Agent is not running - marking instance as unhealthy."
-  Set-InstanceHealth
+
+  # We shut down the instance using the OS here (instead of IMDS and autoscaling API),
+  # because this script will only be needed when the agent itself can't terminate the instance
+  # using IMDS and the autoscaling API. That can happen because the job messed up with the
+  # IMDS setup in the VM or some other weird behavior.
+  Stop-Computer
 }


### PR DESCRIPTION
The health check script is the last resort we have to shut down an instance that doesn't have an agent running. We should not rely on the IMDS and autoscaling API to terminate it since those might have been messed up by the job that ran in that agent.