### PR TITLE
fix: use IMDS and autoscaling API on macOS health check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "aws-cdk": "^2.58.0",
         "aws-cdk-lib": "^2.58.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },

--- a/packer/macos/files/health-check.sh
+++ b/packer/macos/files/health-check.sh
@@ -8,15 +8,28 @@ else
   export PATH=/usr/local/bin:$PATH
 fi
 
+mark_as_unhealthy() {
+  local __token__=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
+  local __instance_id__=$(curl -H "X-aws-ec2-metadata-token: $__token__" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
+
+  # We unset all AWS related variables to make sure the instance profile is used for this.
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_SESSION_TOKEN
+  rm -rf $HOME/.aws/credentials
+
+  aws autoscaling set-instance-health \
+    --instance-id "${__instance_id__}" \
+    --health-status Unhealthy
+}
+
 procs=$(ps aux | grep "/opt/semaphore/agent/agent start" | grep -v grep)
 if [[ -z ${procs} ]]; then
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is not running - marking instance as unhealthy."
 
-  # We shut down the instance using the OS here (instead of IMDS and autoscaling API),
-  # because this script will only be needed when the agent itself can't terminate the instance
-  # using IMDS and the autoscaling API. That can happen because the job messed up with the
-  # IMDS setup in the VM or some other weird behavior.
-  sudo shutdown -h now
+  # Differently from linux/windows, there's no way to properly shutdown a macOS instance from the OS.
+  # So, on macOS, we need to use the IMDS and the autoscaling API to terminate the instance.
+  mark_as_unhealthy
 else
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is running."
 fi


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/renderedtext/agent-aws-stack/pull/126. There's no proper way to shut down an instance running on top of a macOS dedicated host from the OS. So, we revert the health check script to use IMDS and the autoscaling API.