### PR TITLE
fix: use EC2LaunchV2-Windows_Server-2019-English-Full-Base AMI

### DIFF
--- a/packer/windows/windows.pkr.hcl
+++ b/packer/windows/windows.pkr.hcl
@@ -70,7 +70,7 @@ source "amazon-ebs" "windows" {
     owners = ["801119661308"]
 
     filters = {
-      name                = "EC2LaunchV2-Windows_Server-2019-English-Full-ContainersLatest*"
+      name                = "EC2LaunchV2-Windows_Server-2019-English-Full-Base*"
       architecture        = "${var.arch}"
       root-device-type    = "ebs"
       virtualization-type = "hvm"


### PR DESCRIPTION
The `Windows_Server-2019-English-Full-ContainersLatest` image has been removed due to its usage of the Docker EE runtime. We should use a base AMI with no container support for Windows, since that's the common use case.