### PR TITLE
fix: do not use ansible proxy when provisioning linux

### DIFF
--- a/packer/linux/ubuntu-focal.pkr.hcl
+++ b/packer/linux/ubuntu-focal.pkr.hcl
@@ -89,6 +89,7 @@ build {
   provisioner "ansible" {
     playbook_file = "ansible/ubuntu-focal.yml"
     user          = "ubuntu"
+    use_proxy     = false
     extra_arguments = [
       "--skip-tags",
       "reboot",


### PR DESCRIPTION
The issue is related to https://github.com/hashicorp/packer-plugin-ansible/issues/69. We could [pin the plugin's version to v1.1.0](https://github.com/hashicorp/packer-plugin-ansible/issues/69#issuecomment-1631493391), but since we don't need to use a proxy adapter (our target has an IP), we'll use [use_proxy=false](https://developer.hashicorp.com/packer/plugins/provisioners/ansible/ansible#use_proxy) instead.