### PR TITLE
improve health check shutdown

### DIFF
--- a/packer/macos/files/health-check.sh
+++ b/packer/macos/files/health-check.sh
@@ -8,28 +8,15 @@ else
   export PATH=/usr/local/bin:$PATH
 fi
 
-mark_as_unhealthy() {
-  local __token__=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
-  local __instance_id__=$(curl -H "X-aws-ec2-metadata-token: $__token__" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
-
-  # We unset all AWS related variables to make sure the instance profile is used for this.
-  unset AWS_ACCESS_KEY_ID
-  unset AWS_SECRET_ACCESS_KEY
-  unset AWS_SESSION_TOKEN
-  rm -rf $HOME/.aws/credentials
-
-  aws autoscaling set-instance-health \
-    --instance-id "${__instance_id__}" \
-    --health-status Unhealthy
-}
-
 procs=$(ps aux | grep "/opt/semaphore/agent/agent start" | grep -v grep)
 if [[ -z ${procs} ]]; then
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is not running - marking instance as unhealthy."
 
-  # Differently from linux/windows, there's no way to properly shutdown a macOS instance from the OS.
-  # So, on macOS, we need to use the IMDS and the autoscaling API to terminate the instance.
-  mark_as_unhealthy
+  # We shut down the instance using the OS here (instead of IMDS and autoscaling API),
+  # because this script will only be needed when the agent itself can't terminate the instance
+  # using IMDS and the autoscaling API. That can happen because the job messed up with the
+  # IMDS setup in the VM or some other weird behavior.
+  sudo launchctl reboot halt
 else
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Agent is running."
 fi


### PR DESCRIPTION
- fix: add lambda DeleteFunctionConcurrency and ListTags to execution policy (#122)
- feat: put lambda in vpc, if vpc is used (#123)
- fix: remove DeleteLogGroup permission from instance profile (#124)
- build: update agent version to v2.2.8 (#125)
- fix: use OS shutdown on health check script (#126)
- feat: migrate to EC2Launch v2 (#128)
- build: bump release to v0.2.13 (#129)
- fix: use IMDS and autoscaling API on macOS health check (#130)
- fix: use EC2LaunchV2-Windows_Server-2019-English-Full-Base AMI (#134)
- fix: do not use ansible proxy when provisioning linux (#135)
- fix: upgrade cdk libs to ^2.91.0 (#136)
- build: upgrade Ansible to 7.x (#137)
- build: security checks (#138)
- build: update toolbox to v1.20.5 (#131)
- build: update stack version (#139)
- Create CODEOWNERS
- build(deps-dev): bump @babel/traverse from 7.20.10 to 7.23.2 (#141)
- feat: use pre-signed URL as agent registration name (#142)
- improve macOS health check shutdown
