### PR TITLE
fix: do not use NODEJS_14_X lambda runtime

### DIFF
--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -497,7 +497,7 @@ class AwsSemaphoreAgentStack extends Stack {
 
     let suspenderFunction = new Function(this, 'azRebalanceSuspenderLambda', {
       description: "Suspend AZRebalance process for auto scaling group",
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_18_X,
       code: new AssetCode("lambdas/az-rebalance-suspender"),
       handler: "app.handler",
       role: suspenderRole,

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -497,7 +497,7 @@ class AwsSemaphoreAgentStack extends Stack {
 
     let suspenderFunction = new Function(this, 'azRebalanceSuspenderLambda', {
       description: "Suspend AZRebalance process for auto scaling group",
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_16_X,
       code: new AssetCode("lambdas/az-rebalance-suspender"),
       handler: "app.handler",
       role: suspenderRole,

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -61,7 +61,7 @@ class DynamicSSHKeysUpdater extends Construct {
 
     let lambdaFunction = new Function(this, 'Lambda', {
       description: `Check if GitHub SSH public keys have changed.`,
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_16_X,
       timeout: Duration.seconds(10),
       code: new AssetCode('lambdas/ssh-keys-updater'),
       handler: 'app.handler',

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -61,7 +61,7 @@ class DynamicSSHKeysUpdater extends Construct {
 
     let lambdaFunction = new Function(this, 'Lambda', {
       description: `Check if GitHub SSH public keys have changed.`,
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_18_X,
       timeout: Duration.seconds(10),
       code: new AssetCode('lambdas/ssh-keys-updater'),
       handler: 'app.handler',

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -602,7 +602,7 @@ describe("auto scaling group", () => {
 
     template.hasResourceProperties("AWS::Lambda::Function", {
       Description: "Suspend AZRebalance process for auto scaling group",
-      Runtime: "nodejs14.x",
+      Runtime: "nodejs16.x",
       Code: Match.anyValue(),
       Handler: "app.handler",
       Role: Match.anyValue()
@@ -781,7 +781,7 @@ describe("SSH keys updater lambda", () => {
     const template = createTemplate(basicArgumentStore());
     template.hasResourceProperties("AWS::Lambda::Function", {
       Description: "Check if GitHub SSH public keys have changed.",
-      Runtime: "nodejs14.x",
+      Runtime: "nodejs16.x",
       Timeout: 10,
       Code: Match.anyValue(),
       Handler: "app.handler",


### PR DESCRIPTION
AWS [no longer supports Node 14.X](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-14-x-in-the-aws-sdk-for-javascript-v3/), so we need to use a newer version.