### PR TITLE
Use EC2 Root Volume Replacement to replace macOS hosts

### DIFF
--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -94,6 +94,18 @@ class AwsSemaphoreAgentStack extends Stack {
         new PolicyStatement({
           effect: Effect.ALLOW,
           actions: [
+            "ec2:CreateReplaceRootVolumeTask"
+          ],
+          resources: [`arn:aws:ec2:*:${this.account}:instance/*`],
+          conditions: [
+            StringLike: {
+              "aws:userid": "*:${ec2:InstanceID}"
+            }
+          ]
+        }),
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
             "autoscaling:SetInstanceHealth",
             "autoscaling:TerminateInstanceInAutoScalingGroup"
           ],

--- a/packer/macos/files/terminate-instance.sh
+++ b/packer/macos/files/terminate-instance.sh
@@ -28,7 +28,7 @@ if [[ $SEMAPHORE_AGENT_SHUTDOWN_REASON == "IDLE" ]]; then
     --instance-id "$instance_id" \
     --should-decrement-desired-capacity
 else
-  aws ec2 create-replace-root-volume-task	\
+  aws ec2 create-replace-root-volume-task \
     --region "$region" \
     --instance-id "$instance_id" \
     --image-id "$ami_id" \

--- a/packer/macos/files/terminate-instance.sh
+++ b/packer/macos/files/terminate-instance.sh
@@ -11,6 +11,7 @@ fi
 
 token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
 instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
+ami_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/ami-id")
 region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
 
 # We unset all AWS related variables to make sure the instance profile is always used.
@@ -27,8 +28,9 @@ if [[ $SEMAPHORE_AGENT_SHUTDOWN_REASON == "IDLE" ]]; then
     --instance-id "$instance_id" \
     --should-decrement-desired-capacity
 else
-  aws autoscaling terminate-instance-in-auto-scaling-group \
+  aws ec2 create-replace-root-volume-task	\
     --region "$region" \
     --instance-id "$instance_id" \
-    --no-should-decrement-desired-capacity
+    --image-id "$ami_id" \
+    –-delete-replaced-root-volume
 fi


### PR DESCRIPTION
Currently, this stack recycles (terminates) each EC2 instance after it has successfully executed a single CI job to ensure that each CI job has a fresh environment without any risk of broken tooling/configuration from a previous job/execution.

However, this pattern is problematic for macOS machines as [EC2 Mac does not bill per-second](https://aws.amazon.com/ec2/instance-types/mac/):

> Billing for EC2 Mac instances is per second with a 24-hour minimum allocation period to comply with the Apple macOS Software License Agreement

As a result, a CI job that takes only a few seconds or even a full hour (the default timeout) will be billed for 24 hours of compute time which can quickly become expensive.

Fortunately, there is a potential solution. EC2 has support for quickly restoring a instance to it’s original state: [Quickly Restore Amazon EC2 Mac Instances using Replace Root Volume capability](https://aws.amazon.com/blogs/compute/new-reset-amazon-ec2-mac-instances-to-a-known-state-using-replace-root-volume-capability/):

> The second use case is during continuous integration and continuous deployment (CI/CD) when you need to restore an Amazon EC2 Mac instance to a defined well-known state at the end of a build.
>
> To restart your EC2 Mac instance in its initial state without stopping or terminating them, we created the ability to replace the root volume of an Amazon EC2 Mac instance with another EBS volume. This new EBS volume is created either from a new AMI, an Amazon EBS Snapshot, or from the initial volume state during boot.

This PR attempts to implement this feature by adding the `ec2:CreateReplaceRootVolumeTask` IAM action/permission to the instance IAM role (utilizing the [aws:userid condition trick](https://stackoverflow.com/a/71500922) to limit that action to only the instance itself making the request). Then, instead of using calling `TerminateInstanceInAutoScalingGroup` when an instance needs to be replaced, it will call `CreateReplaceRootVolumeTask` using it's own instance ID and AMI ID (extracted via the metadata service) to restart the machine with a fresh OS image.

NOTE: I have not tested this change, most notably I am concerned about this note in the [aws blog post](https://aws.amazon.com/blogs/compute/new-reset-amazon-ec2-mac-instances-to-a-known-state-using-replace-root-volume-capability/):
> During the replacement, the instance will be unable to respond to health checks and hence might be marked as unhealthy if placed inside an Auto Scaled Group. You can write a [custom health check](https://aws.amazon.com/blogs/compute/how-to-create-custom-health-checks-for-your-amazon-ec2-auto-scaling-fleet/) to change that behavior.

It's unclear if such a custom health check would be required for this use-case or if the instance will restart quickly enough. It probably wouldn't be a bad idea in general to add a custom health check that actually marks the instance in-service when the Semaphore agent process is online...