### PR TITLE
fix: update all lambdas to use node 18.x runtime

### DIFF
--- a/lambdas/az-rebalance-suspender/app.js
+++ b/lambdas/az-rebalance-suspender/app.js
@@ -1,15 +1,20 @@
-var aws = require("aws-sdk");
+const { Agent } = require("https");
+const { AutoScalingClient, SuspendProcessesCommand } = require("@aws-sdk/client-auto-scaling");
 
-function suspendAutoScalingProcess(autoScalingGroupName) {
+const CONNECTION_TIMEOUT = 1000;
+const SOCKET_TIMEOUT = 1000;
+
+function suspendAutoScalingProcess(autoScalingClient, autoScalingGroupName) {
   console.log(`Suspending AZRebalance process for ${autoScalingGroupName}...`)
-  const autoscaling = new aws.AutoScaling();
+
   const params = {
     AutoScalingGroupName: autoScalingGroupName,
     ScalingProcesses: ["AZRebalance"]
   }
 
   return new Promise(function(resolve, reject) {
-    autoscaling.suspendProcesses(params, function(err, _data) {
+    const command = new SuspendProcessesCommand(params);
+    autoScalingClient.send(command, function(err, _data) {
       if (err) {
         reject(err);
       } else {
@@ -21,8 +26,20 @@ function suspendAutoScalingProcess(autoScalingGroupName) {
 
 exports.handler = async (event, context, callback) => {
   console.log('Received event: ', JSON.stringify(event, null, 2));
+
+  const autoScalingClient = new AutoScalingClient({
+    maxAttempts: 1,
+    requestHandler: new NodeHttpHandler({
+      connectionTimeout: CONNECTION_TIMEOUT,
+      socketTimeout: SOCKET_TIMEOUT,
+      httpsAgent: new Agent({
+        timeout: SOCKET_TIMEOUT
+      })
+    }),
+  });
+
   if (event.RequestType != "Delete") {
-    await suspendAutoScalingProcess(event.ResourceProperties.AutoScalingGroupName);
+    await suspendAutoScalingProcess(autoScalingClient, event.ResourceProperties.AutoScalingGroupName);
   }
 
   return {

--- a/lambdas/az-rebalance-suspender/app.js
+++ b/lambdas/az-rebalance-suspender/app.js
@@ -1,4 +1,5 @@
 const { Agent } = require("https");
+const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
 const { AutoScalingClient, SuspendProcessesCommand } = require("@aws-sdk/client-auto-scaling");
 
 const CONNECTION_TIMEOUT = 1000;

--- a/lambdas/ssh-keys-updater/app.js
+++ b/lambdas/ssh-keys-updater/app.js
@@ -1,4 +1,5 @@
 const { request, Agent } = require('https');
+const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
 const { SSMClient, GetParameterCommand, PutParameterCommand } = require("@aws-sdk/client-ssm");
 
 const CONNECTION_TIMEOUT = 1000;

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -497,7 +497,7 @@ class AwsSemaphoreAgentStack extends Stack {
 
     let suspenderFunction = new Function(this, 'azRebalanceSuspenderLambda', {
       description: "Suspend AZRebalance process for auto scaling group",
-      runtime: Runtime.NODEJS_16_X,
+      runtime: Runtime.NODEJS_18_X,
       code: new AssetCode("lambdas/az-rebalance-suspender"),
       handler: "app.handler",
       role: suspenderRole,

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -61,7 +61,7 @@ class DynamicSSHKeysUpdater extends Construct {
 
     let lambdaFunction = new Function(this, 'Lambda', {
       description: `Check if GitHub SSH public keys have changed.`,
-      runtime: Runtime.NODEJS_16_X,
+      runtime: Runtime.NODEJS_18_X,
       timeout: Duration.seconds(10),
       code: new AssetCode('lambdas/ssh-keys-updater'),
       handler: 'app.handler',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "aws-cdk": "^2.91.0",
         "aws-cdk-lib": "^2.91.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -602,7 +602,7 @@ describe("auto scaling group", () => {
 
     template.hasResourceProperties("AWS::Lambda::Function", {
       Description: "Suspend AZRebalance process for auto scaling group",
-      Runtime: "nodejs16.x",
+      Runtime: "nodejs18.x",
       Code: Match.anyValue(),
       Handler: "app.handler",
       Role: Match.anyValue()
@@ -781,7 +781,7 @@ describe("SSH keys updater lambda", () => {
     const template = createTemplate(basicArgumentStore());
     template.hasResourceProperties("AWS::Lambda::Function", {
       Description: "Check if GitHub SSH public keys have changed.",
-      Runtime: "nodejs16.x",
+      Runtime: "nodejs18.x",
       Timeout: 10,
       Code: Match.anyValue(),
       Handler: "app.handler",


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6091

The node 16.x runtime will be [deprecated soon](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported), so we need to update to the node 18.x runtime. Since the 18.x runtime only has the [AWS SDK v3 available](https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/), the code was updated to use that SDK.