### PR TITLE
fix: do not shell-out for fetching GH SSH keys

### DIFF
--- a/lib/github-keys.js
+++ b/lib/github-keys.js
@@ -1,6 +1,6 @@
 const path = require("path");
+const { request } = require('https');
 const { readFileSync, writeFileSync, readdirSync, unlinkSync } = require('fs');
-const { execSync } = require('child_process');
 
 // To make sure we don't always hit the Github API
 // to determine its keys, we cache the keys in a local file.
@@ -9,7 +9,7 @@ const cacheFilePrefix = ".gh_ssh_keys";
 // We expire the cache file after 1 hour.
 const expirationPeriod = 60 * 60;
 
-function getKeys() {
+async function getKeys() {
   let cachedFile = findCacheFile()
   if (!cachedFile) {
     const newFilePath = newCacheFileName()
@@ -22,7 +22,7 @@ function getKeys() {
     const newFilePath = newCacheFileName()
     const newFileName = path.basename(newFilePath)
     console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}', but expired. Fetching and storing at '${newFileName}' ...`);
-    const keys = fetchAndStore(newFilePath)
+    const keys = await fetchAndStore(newFilePath)
     unlinkSync(path.resolve(__dirname, '..', cachedFile.fileName))
     return keys
   }
@@ -50,11 +50,43 @@ function findCacheFile() {
   return null
 }
 
-function fetchAndStore(filePath) {
-  meta = execSync(`curl -s https://api.github.com/meta`);
-  let keys = JSON.parse(meta.toString()).ssh_keys
+async function fetchAndStore(filePath) {
+  let keys = await fetchKeys();
   writeFileSync(filePath, JSON.stringify(keys))
   return keys
+}
+
+function fetchKeys() {
+  const options = {
+    hostname: "api.github.com",
+    path: "/meta",
+    method: 'GET',
+    headers: { "User-Agent": "agent-aws-stack" }
+  }
+
+  return new Promise((resolve, reject) => {
+    let data = '';
+
+    request(options, response => {
+      response.on('data', function (chunk) {
+        data += chunk;
+      });
+
+      response.on('end', function () {
+        if (response.statusCode !== 200) {
+          const errMessage = `Request to get GitHub SSH keys failed with ${response.statusCode}`
+          console.error(errMessage);
+          console.error(`Response: ${data}`);
+          console.error(`Headers: ${JSON.stringify(response.headers)}`);
+          reject(errMessage);
+        } else {
+          resolve(JSON.parse(data).ssh_keys);
+        }
+      });
+    })
+    .on('error', error => reject(error))
+    .end();
+  })
 }
 
 function newCacheFileName() {

--- a/lib/github-keys.js
+++ b/lib/github-keys.js
@@ -15,7 +15,7 @@ async function getKeys() {
     const newFilePath = newCacheFileName()
     const newFileName = path.basename(newFilePath)
     console.log(`==> GitHub SSH keys not found locally. Fetching and storing at '${newFileName}' ...`);
-    return fetchAndStore(newFilePath)
+    return await fetchAndStore(newFilePath)
   }
 
   if (cachedFile.expired) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "aws-cdk": "^2.91.0",
         "aws-cdk-lib": "^2.91.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/6192

We are shelling out and using curl to fetch the GitHub SSH keys needed to deploy the stack. That is not ideal since it does not allow us to see the error messages when that HTTP request fails. We should use the native node HTTP request library instead.