### PR TITLE
add DescribeVpnGateways action

### DIFF
--- a/execution-policy.json
+++ b/execution-policy.json
@@ -23,7 +23,8 @@
         "ec2:DescribeLaunchTemplateVersions",
         "ec2:DescribeLaunchTemplates",
         "ec2:GetLaunchTemplateData",
-        "ec2:ModifyLaunchTemplate"
+        "ec2:ModifyLaunchTemplate",
+        "ec2:DescribeVpnGateways"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
We are currently in the process of replicating our agent pools to a different aws region to comply with certain failover requirements. In doing so, we needed to point to new vpc and subnet ids in our config files, but that resulted in this:

```
[Error at /AwsSemaphoreAgentStack] You are not authorized to perform this operation. User: <redacted> is not authorized to perform: ec2:DescribeVpnGateways because no identity-based policy allows the ec2:DescribeVpnGateways action
```

Going into the aws portal and manually adding this action to our policy allowed us to successfully deploy, so we would like this to be included in `execution-policy.json`