### PR TITLE
upgrade CDK to 2.164.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "aws-semaphore-agent",
       "version": "0.3.6",
       "dependencies": {
-        "aws-cdk": "^2.91.0",
-        "aws-cdk-lib": "^2.91.0",
+        "aws-cdk": "^2.164.1",
+        "aws-cdk-lib": "^2.164.1",
         "constructs": "^10.2.69"
       },
       "bin": {
@@ -33,19 +33,51 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.200",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
+      "version": "2.2.209",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.209.tgz",
+      "integrity": "sha512-tL7aBDzx/QBuZoQso9OST2BMCoev89v01iQZicOKlR0J6vWQLPiqZfn4vd9nissFbM4X+xIwi3UKasPBTQL0WQ=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.166",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.166.tgz",
-      "integrity": "sha512-j0xnccpUQHXJKPgCwQcGGNu4lRiC1PptYfdxBIH1L4dRK91iBxtSQHESRQX+yB47oGLaF/WfNN/aF3WXwlhikg=="
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.0",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "38.0.1",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.6.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -1235,9 +1267,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.91.0.tgz",
-      "integrity": "sha512-YSnTiLyNtng0eW1y9XdyopSTP3Kuyhs5cF5iRcaCk9o+3zrvadgxvcWVT7caXNfE8iOI9IKwSd2GiABeVd20eQ==",
+      "version": "2.164.1",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/aws-cdk/-/aws-cdk-2.164.1.tgz",
+      "integrity": "sha512-dWRViQgHLe7GHkPIQGA+8EQSm8TBcxemyCC3HHW3wbLMWUDbspio9Dktmw5EmWxlFjjWh86Dk1JWf1zKQo8C5g==",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -1249,9 +1281,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.91.0.tgz",
-      "integrity": "sha512-sxXVUlb9OOjwakEssppty7QMTcMX9F6/cNA980JMmQpKeVALXvT60jWdCeAeKeZcGz1Y4whLoXLdU2/bJzh07w==",
+      "version": "2.164.1",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/aws-cdk-lib/-/aws-cdk-lib-2.164.1.tgz",
+      "integrity": "sha512-jNvVmfZJbZoAYU94b5dzTlF2z6JXJ204NgcYY5haOa6mq3m2bzdYPXnPtB5kpAX3oBi++yoRdmLhqgckdEhUZA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1262,21 +1294,24 @@
         "punycode",
         "semver",
         "table",
-        "yaml"
+        "yaml",
+        "mime-types"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.166",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1292,14 +1327,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1389,8 +1424,13 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1408,7 +1448,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.2",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1452,15 +1492,23 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.6"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
@@ -1475,7 +1523,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1491,12 +1539,9 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.3",
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1545,7 +1590,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1560,25 +1605,12 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -3890,19 +3922,38 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.200",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
+      "version": "2.2.209",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.209.tgz",
+      "integrity": "sha512-tL7aBDzx/QBuZoQso9OST2BMCoev89v01iQZicOKlR0J6vWQLPiqZfn4vd9nissFbM4X+xIwi3UKasPBTQL0WQ=="
     },
     "@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.166",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.166.tgz",
-      "integrity": "sha512-j0xnccpUQHXJKPgCwQcGGNu4lRiC1PptYfdxBIH1L4dRK91iBxtSQHESRQX+yB47oGLaF/WfNN/aF3WXwlhikg=="
+    "@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.0",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "38.0.1",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "requires": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.3"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "7.6.3",
+          "bundled": true
+        }
+      }
     },
     "@babel/code-frame": {
       "version": "7.22.13",
@@ -4849,30 +4900,32 @@
       }
     },
     "aws-cdk": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.91.0.tgz",
-      "integrity": "sha512-YSnTiLyNtng0eW1y9XdyopSTP3Kuyhs5cF5iRcaCk9o+3zrvadgxvcWVT7caXNfE8iOI9IKwSd2GiABeVd20eQ==",
+      "version": "2.164.1",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/aws-cdk/-/aws-cdk-2.164.1.tgz",
+      "integrity": "sha512-dWRViQgHLe7GHkPIQGA+8EQSm8TBcxemyCC3HHW3wbLMWUDbspio9Dktmw5EmWxlFjjWh86Dk1JWf1zKQo8C5g==",
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.91.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.91.0.tgz",
-      "integrity": "sha512-sxXVUlb9OOjwakEssppty7QMTcMX9F6/cNA980JMmQpKeVALXvT60jWdCeAeKeZcGz1Y4whLoXLdU2/bJzh07w==",
+      "version": "2.164.1",
+      "resolved": "https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/npm/confluent-npm/aws-cdk-lib/-/aws-cdk-lib-2.164.1.tgz",
+      "integrity": "sha512-jNvVmfZJbZoAYU94b5dzTlF2z6JXJ204NgcYY5haOa6mq3m2bzdYPXnPtB5kpAX3oBi++yoRdmLhqgckdEhUZA==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.166",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -4881,13 +4934,13 @@
           "bundled": true
         },
         "ajv": {
-          "version": "8.12.0",
+          "version": "8.17.1",
           "bundled": true,
           "requires": {
-            "fast-deep-equal": "^3.1.1",
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "require-from-string": "^2.0.2"
           }
         },
         "ansi-regex": {
@@ -4944,8 +4997,12 @@
           "version": "3.1.3",
           "bundled": true
         },
+        "fast-uri": {
+          "version": "3.0.1",
+          "bundled": true
+        },
         "fs-extra": {
-          "version": "11.1.1",
+          "version": "11.2.0",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -4958,7 +5015,7 @@
           "bundled": true
         },
         "ignore": {
-          "version": "5.2.4",
+          "version": "5.3.2",
           "bundled": true
         },
         "is-fullwidth-code-point": {
@@ -4985,11 +5042,15 @@
           "version": "4.4.2",
           "bundled": true
         },
-        "lru-cache": {
-          "version": "6.0.0",
+        "mime-db": {
+          "version": "1.52.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.35",
           "bundled": true,
           "requires": {
-            "yallist": "^4.0.0"
+            "mime-db": "1.52.0"
           }
         },
         "minimatch": {
@@ -5000,7 +5061,7 @@
           }
         },
         "punycode": {
-          "version": "2.3.0",
+          "version": "2.3.1",
           "bundled": true
         },
         "require-from-string": {
@@ -5008,11 +5069,8 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.5.4",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "bundled": true
         },
         "slice-ansi": {
           "version": "4.0.0",
@@ -5040,7 +5098,7 @@
           }
         },
         "table": {
-          "version": "6.8.1",
+          "version": "6.8.2",
           "bundled": true,
           "requires": {
             "ajv": "^8.0.1",
@@ -5051,18 +5109,7 @@
           }
         },
         "universalify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
+          "version": "2.0.1",
           "bundled": true
         },
         "yaml": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "jest": "^29.3.1"
   },
   "dependencies": {
-    "aws-cdk": "^2.91.0",
-    "aws-cdk-lib": "^2.91.0",
+    "aws-cdk": "^2.164.1",
+    "aws-cdk-lib": "^2.164.1",
     "constructs": "^10.2.69"
   }
 }


### PR DESCRIPTION
This upgrades the CDK version to the latest version.

I am specifically interested in this upgrade because it addresses https://www.aquasec.com/blog/aws-cdk-risk-exploiting-a-missing-s3-bucket-allowed-account-takeover/.