### PR TITLE
fix(windows): do not restart agent after a shutdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "aws-cdk": "^2.164.1",
         "aws-cdk-lib": "^2.164.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.3.8",
+      "version": "0.4.0",
       "dependencies": {
         "aws-cdk": "^2.164.1",
         "aws-cdk-lib": "^2.164.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },

--- a/packer/windows/scripts/start-agent.ps1
+++ b/packer/windows/scripts/start-agent.ps1
@@ -186,8 +186,7 @@ nssm install semaphore-agent C:\semaphore-agent\agent.exe start --config-file C:
 nssm set semaphore-agent ObjectName .\$UserName $Password
 nssm set semaphore-agent AppStdout C:\semaphore-agent\agent.log
 nssm set semaphore-agent AppStderr C:\semaphore-agent\agent.log
-nssm set semaphore-agent AppExit Default Restart
-nssm set semaphore-agent AppRestartDelay 10000
+nssm set semaphore-agent AppExit Default Exit
 
 # For some reason, the `nssm start` command started failing without any output
 # after the upgrade to EC2Launch v2, even though the agent service starts just fine.


### PR DESCRIPTION
There's no need to restart agents now that we have a health check script running.

Ref: https://github.com/renderedtext/tasks/issues/7496