### PR TITLE
fix GitHub SSH keys error handling

### DIFF
--- a/bin/aws-semaphore-agent.js
+++ b/bin/aws-semaphore-agent.js
@@ -3,7 +3,7 @@
 const { App, Tags } = require('aws-cdk-lib');
 const { AwsSemaphoreAgentStack } = require('../lib/aws-semaphore-agent-stack');
 const { ArgumentStore } = require('../lib/argument-store');
-const { getKeys } = require('../lib/github-keys');
+const { getKeys, GitHubKeysError } = require('../lib/github-keys');
 
 const app = new App();
 const argumentStore = buildArgumentStore();
@@ -27,7 +27,11 @@ getKeys()
     });
   })
   .catch(e => {
-    console.error("Error fetching GitHub SSH keys", e)
+    if (e instanceof GitHubKeysError) {
+      console.error("Error fetching GitHub SSH keys", e);
+    } else {
+      throw e;
+    }
   })
 
 function buildArgumentStore() {

--- a/lib/github-keys.js
+++ b/lib/github-keys.js
@@ -9,26 +9,37 @@ const cacheFilePrefix = ".gh_ssh_keys";
 // We expire the cache file after 1 hour.
 const expirationPeriod = 60 * 60;
 
+class GitHubKeysError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "GitHubKeysError";
+  }
+}
+
 async function getKeys() {
-  let cachedFile = findCacheFile()
-  if (!cachedFile) {
-    const newFilePath = newCacheFileName()
-    const newFileName = path.basename(newFilePath)
-    console.log(`==> GitHub SSH keys not found locally. Fetching and storing at '${newFileName}' ...`);
-    return await fetchAndStore(newFilePath)
-  }
+  try {
+    let cachedFile = findCacheFile()
+    if (!cachedFile) {
+      const newFilePath = newCacheFileName()
+      const newFileName = path.basename(newFilePath)
+      console.log(`==> GitHub SSH keys not found locally. Fetching and storing at '${newFileName}' ...`);
+      return await fetchAndStore(newFilePath)
+    }
 
-  if (cachedFile.expired) {
-    const newFilePath = newCacheFileName()
-    const newFileName = path.basename(newFilePath)
-    console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}', but expired. Fetching and storing at '${newFileName}' ...`);
-    const keys = await fetchAndStore(newFilePath)
-    unlinkSync(path.resolve(__dirname, '..', cachedFile.fileName))
-    return keys
-  }
+    if (cachedFile.expired) {
+      const newFilePath = newCacheFileName()
+      const newFileName = path.basename(newFilePath)
+      console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}', but expired. Fetching and storing at '${newFileName}' ...`);
+      const keys = await fetchAndStore(newFilePath)
+      unlinkSync(path.resolve(__dirname, '..', cachedFile.fileName))
+      return keys
+    }
 
-  console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}'.`);
-  return JSON.parse(readFileSync(cachedFile.fileName).toString())
+    console.log(`==> GitHub SSH keys found locally at '${cachedFile.fileName}'.`);
+    return JSON.parse(readFileSync(cachedFile.fileName).toString())
+  } catch (error) {
+    throw new GitHubKeysError("An unexpected error occurred while fetching GitHub Keys: " + error);
+  }
 }
 
 function findCacheFile() {
@@ -97,4 +108,4 @@ function epochSeconds() {
   return Math.floor(new Date().getTime() / 1000)
 }
 
-module.exports = { getKeys }
+module.exports = { getKeys, GitHubKeysError }


### PR DESCRIPTION
This changes the GitHub SSH keys error handling logic when building the CDK objects to throw and catch a specific error rather than all errors. Previously, it caught all errors and then continued on. This meant that an error in a specific CDK object could cause an error and CDK would continue processing the stack. In my case, this meant that an incomplete set of objects were created resulting in a large change set and the deletion of most of the resources in my stack.

### Testing
Tested manually:
```
> npm run deploy:ci

> aws-semaphore-agent@0.3.7 deploy:ci
> cdk deploy --require-approval never --progress events

==> No config file specified. Using environment variables ...
==> GitHub SSH keys found locally at '.gh_ssh_keys_1740499296', but expired. Fetching and storing at '.gh_ssh_keys_1740503496' ...
[WARNING] aws-cdk-lib.aws_ec2.LaunchTemplateProps#keyName is deprecated.
  - Use `keyPair` instead - https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2-readme.html#using-an-existing-ec2-key-pair
  This API will be removed in the next major release.
/Users/coreychristous/workspace/agent-aws-stack/lib/aws-semaphore-agent-stack.js:54
    console.log(`securityGroup: ${JSON.stringify(securityGroup)}`)
                                              ^

TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'SecurityGroup'
    |     property 'node' -> object with constructor 'Node'
    --- property 'host' closes the circle
    at JSON.stringify (<anonymous>)
    at new AwsSemaphoreAgentStack (/Users/coreychristous/workspace/agent-aws-stack/lib/aws-semaphore-agent-stack.js:54:47)
    at /Users/coreychristous/workspace/agent-aws-stack/bin/aws-semaphore-agent.js:13:36
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.17.1

```

In this, we can see that an error in the `aws-semaphore-agent-stack.js` file now raises an uncaught error properly and the CDK deploy doesn't take place.