### PR TITLE
explicitly set scaler lambda subnets

### DIFF
--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -284,12 +284,23 @@ class AwsSemaphoreAgentStack extends Stack {
         vpcId: this.argumentStore.get("SEMAPHORE_AGENT_VPC_ID")
       })
 
-      opts.vpcSubnets = {
-        subnetType: SubnetType.PRIVATE_WITH_EGRESS
+      // Only lookup the subnets if they aren't already explicitly set.
+      // If they are explicitly set, we assume the user knows what they are doing.
+      if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_VPC_ID") && this.argumentStore.isEmpty("SEMAPHORE_AGENT_SUBNETS")) {
+        opts.vpcSubnets = {
+          subnetType: SubnetType.PRIVATE_WITH_EGRESS
+        }
       }
     }
 
     let lambdaFunction = new Function(this, 'scalerLambda', opts);
+
+    // if the subnets are explicitly set already, use them.
+    // This can specifically be used to support the case where an AWS network firewall is in place on the desired subnet,
+    // and SubnetType can't properly detect the subnet to use.
+    if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_VPC_ID") && !this.argumentStore.isEmpty("SEMAPHORE_AGENT_SUBNETS")) {
+      lambdaFunction.node.defaultChild.vpcConfig.subnetIds = this.argumentStore.getAsList("SEMAPHORE_AGENT_SUBNETS");
+    }
 
     lambdaFunction.node.addDependency(lambdaDependencies);
     return lambdaFunction;

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -654,6 +654,35 @@ describe("scaler lambda", () => {
     });
   })
 
+  test("VPC with subnets", () => {
+    const argumentStore = basicArgumentStore();
+    argumentStore.set("SEMAPHORE_AGENT_USE_IPV6", "true");
+    argumentStore.set("SEMAPHORE_AGENT_VPC_ID", "vpc-1234");
+    argumentStore.set("SEMAPHORE_AGENT_SUBNETS", "subnet-1234,subnet-5678");
+
+    const template = createTemplate(argumentStore);
+    template.hasResourceProperties("AWS::Lambda::Function", {
+        VpcConfig: {
+            SecurityGroupIds: [Match.anyValue()],
+            SubnetIds: ["subnet-1234", "subnet-5678"]
+        }
+    });
+  })
+
+  test("VPC without subnets", () => {
+    const argumentStore = basicArgumentStore();
+    argumentStore.set("SEMAPHORE_AGENT_USE_IPV6", "true");
+    argumentStore.set("SEMAPHORE_AGENT_VPC_ID", "vpc-1234");
+
+    const template = createTemplate(argumentStore);
+    template.hasResourceProperties("AWS::Lambda::Function", {
+        VpcConfig: {
+            SecurityGroupIds: [Match.anyValue()],
+            SubnetIds: ["p-12345", "p-67890"]
+        }
+    });
+  })
+
   test("using number overprovisioning strategy", () => {
     const argumentStore = basicArgumentStore();
     argumentStore.set("SEMAPHORE_AGENT_OVERPROVISION_STRATEGY", "number");


### PR DESCRIPTION
This changes the Scaler lambda to use a different set of subnets depending upon the provided configuration:
* If `SEMAPHORE_AGENT_SUBNETS` and `SEMAPHORE_AGENT_VPC_ID` are set, then the given subnets will be used for the Scaler
* If `SEMAPHORE_AGENT_SUBNETS` is not set and `SEMAPHORE_AGENT_VPC_ID` is set, then the existing lookup will be used. The existing lookup tries to find a private subnet with egress to the internet.

This change is needed because the existing lookup didn't work for me when the private subnets were configured with an AWS network firewall sitting in between the private and public subnets:
```
Error: There are no 'Private' subnet groups in this VPC. Available types: Isolated,Deprecated_Isolated,Public
    at LookedUpVpc.selectSubnetObjectsByType (/tmp/agent-aws-stack-0.4.0/node_modules/aws-cdk-lib/aws-ec2/lib/vpc.js:1:6197)
    at LookedUpVpc.selectSubnetObjects (/tmp/agent-aws-stack-0.4.0/node_modules/aws-cdk-lib/aws-ec2/lib/vpc.js:1:4915)
    at LookedUpVpc.selectSubnets (/tmp/agent-aws-stack-0.4.0/node_modules/aws-cdk-lib/aws-ec2/lib/vpc.js:1:2603)
    at Function.configureVpc (/tmp/agent-aws-stack-0.4.0/node_modules/aws-cdk-lib/aws-lambda/lib/function.js:1:24939)
    at new Function (/tmp/agent-aws-stack-0.4.0/node_modules/aws-cdk-lib/aws-lambda/lib/function.js:1:13077)
    at AwsSemaphoreAgentStack.createScalerLambda (/tmp/agent-aws-stack-0.4.0/lib/aws-semaphore-agent-stack.js:292:26)
    at new AwsSemaphoreAgentStack (/tmp/agent-aws-stack-0.4.0/lib/aws-semaphore-agent-stack.js:50:31)
    at /tmp/agent-aws-stack-0.4.0/bin/aws-semaphore-agent.js:13:36
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```


### Testing
Added a unit tests which covered both scenarios.

Ran a local deploy to a stack that I own and the change set didn't show any difference.