### PR TITLE
allow public subnets for scaler lambda

### DIFF
--- a/lib/argument-store.js
+++ b/lib/argument-store.js
@@ -39,6 +39,7 @@ class ArgumentStore {
     "SEMAPHORE_AGENT_OVERPROVISION_STRATEGY": "none",
     "SEMAPHORE_AGENT_OVERPROVISION_FACTOR": "0",
     "SEMAPHORE_AGENT_USE_IPV6": "false",
+    "SEMAPHORE_AGENT_ALLOW_PUBLIC_SUBNET": "false",
   }
 
   static validOverprovisionStrategies = ["none", "number", "percentage"]

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -280,7 +280,6 @@ class AwsSemaphoreAgentStack extends Stack {
       allowPublicSubnet: this.argumentStore.getAsBool("SEMAPHORE_AGENT_ALLOW_PUBLIC_SUBNET"),
     }
 
-
     if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_VPC_ID")) {
       opts.vpc = Vpc.fromLookup(this, 'LambdaVPC', {
         vpcId: this.argumentStore.get("SEMAPHORE_AGENT_VPC_ID")

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -276,8 +276,10 @@ class AwsSemaphoreAgentStack extends Stack {
         "SEMAPHORE_ENDPOINT": this.argumentStore.getSemaphoreEndpoint(),
         "SEMAPHORE_AGENT_OVERPROVISION_STRATEGY": this.argumentStore.get("SEMAPHORE_AGENT_OVERPROVISION_STRATEGY"),
         "SEMAPHORE_AGENT_OVERPROVISION_FACTOR": this.argumentStore.get("SEMAPHORE_AGENT_OVERPROVISION_FACTOR"),
-      }
+      },
+      allowPublicSubnet: this.argumentStore.getAsBool("SEMAPHORE_AGENT_ALLOW_PUBLIC_SUBNET"),
     }
+
 
     if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_VPC_ID")) {
       opts.vpc = Vpc.fromLookup(this, 'LambdaVPC', {


### PR DESCRIPTION
This adds a new `SEMAPHORE_AGENT_ALLOW_PUBLIC_SUBNET` parameter, which allows the Scaler lambda to run in a public subnet.

When a public subnet is provided and this setting is not enabled, the deploy shows:
```
Error: Lambda Functions in a public subnet can NOT access the internet. If you are aware of this limitation and would still like to place the function in a public subnet, set `allowPublicSubnet` to true
```

### Testing
I started looking into adding a unit test for this, but there wasn't a clear and easy path since the `allowPublicSubnet` option doesn't actually change the CloudFormation template in any way. This setting is only a CDK construct. If you want I unit test for it, I can do so, but some substantial changes may be necessary.

I ran a manual deploy using this feature and it worked as expected.