### PR TITLE
fix: install erlang from cloudsmith repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "aws-cdk": "^2.164.1",
         "aws-cdk-lib": "^2.164.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },

--- a/packer/linux/ansible/group_vars/all.yml
+++ b/packer/linux/ansible/group_vars/all.yml
@@ -8,6 +8,4 @@ docker_apt_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ an
 docker_apt_gpg_key: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
 yq_url: "https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64"
 cloudwatch_agent_url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
-erlang_apt_gpg_key: https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
-erlang_apt_repository: "deb [arch=amd64] https://packages.erlang-solutions.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} contrib"
 systemd_restart_seconds: 300

--- a/packer/linux/ansible/group_vars/all.yml
+++ b/packer/linux/ansible/group_vars/all.yml
@@ -9,6 +9,6 @@ docker_apt_gpg_key: "https://download.docker.com/linux/{{ ansible_distribution |
 yq_url: "https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64"
 erlang_gpg_key_url: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
 erlang_gpg_key_checksum: "84df2e5fd80d464c3eb9acd2f751b2f6a723438200915dd50fbf12f08698e4ec"
-erlang_gpg_key_path: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
+erlang_gpg_key_path: /usr/share/keyrings/rabbitmq-erlang.E495BB49CC4BBE5B.asc
 cloudwatch_agent_url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
 systemd_restart_seconds: 300

--- a/packer/linux/ansible/group_vars/all.yml
+++ b/packer/linux/ansible/group_vars/all.yml
@@ -7,5 +7,8 @@ awscli_url: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-{{ awscli_vers
 docker_apt_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
 docker_apt_gpg_key: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
 yq_url: "https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64"
+erlang_gpg_key_url: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
+erlang_gpg_key_checksum: "84df2e5fd80d464c3eb9acd2f751b2f6a723438200915dd50fbf12f08698e4ec"
+erlang_gpg_key_path: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
 cloudwatch_agent_url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
 systemd_restart_seconds: 300

--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -13,13 +13,13 @@
 
 - name: "Add repository to APT sources list"
   ansible.builtin.apt_repository:
-  repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
-  state: present
+    repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
+    state: present
 
 - name: "Add src repository to APT sources list"
   ansible.builtin.apt_repository:
-  repo: "deb-src [signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
-  state: present
+    repo: "deb-src [signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
+    state: present
 
 - name: Install Erlang
   when: install_erlang | bool

--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -17,6 +17,8 @@
   ansible.builtin.apt_repository:
     repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
     state: present
+  tags:
+    - skip_ansible_lint
 
 - name: "Add src repository to APT sources list"
   ansible.builtin.apt_repository:

--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -2,16 +2,10 @@
 - name: Download GPG key
   ansible.builtin.get_url:
     url: "{{ erlang_gpg_key_url }}"
-    dest: "{{ erlang_gpg_key_path }}_armored"
+    dest: "{{ erlang_gpg_key_path }}"
     checksum: "sha256:{{ erlang_gpg_key_checksum }}"
     mode: '0755'
     force: true
-
-- name: De-Armor GPG key
-  ansible.builtin.command: gpg --dearmor < {{ erlang_gpg_key_path }}_armored > {{ erlang_gpg_key_path }}
-  no_log: true
-  args:
-    creates: "{{ erlang_gpg_key_path }}"
 
 - name: "Add repository to APT sources list"
   ansible.builtin.apt_repository:

--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -1,6 +1,28 @@
 ---
+- name: Download GPG key
+  get_url:
+    url: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
+    dest: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg_armored
+    checksum: sha256:84df2e5fd80d464c3eb9acd2f751b2f6a723438200915dd50fbf12f08698e4ec
+
+- name: De-Armor GPG key
+  command: gpg --dearmor < /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg_armored > /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
+  no_log: true
+  args:
+    creates: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
+
+- name: "Add repository to APT sources list"
+  ansible.builtin.apt_repository:
+  repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
+  state: present
+
+- name: "Add src repository to APT sources list"
+  ansible.builtin.apt_repository:
+  repo: "deb-src [signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
+  state: present
+
 - name: Install Erlang
   when: install_erlang | bool
   ansible.builtin.apt:
     pkg:
-      - erlang-base=1:24.3.3-1
+      - erlang-base=1:24.3.4.17-1

--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -1,17 +1,4 @@
 ---
-- name: Add Erlang GPG apt Key
-  when: install_erlang | bool
-  ansible.builtin.apt_key:
-    url: "{{ erlang_apt_gpg_key }}"
-    state: present
-
-- name: Add Erlang Repository
-  when: install_erlang | bool
-  ansible.builtin.apt_repository:
-    repo: "{{ erlang_apt_repository }}"
-    state: present
-    update_cache: true
-
 - name: Install Erlang
   when: install_erlang | bool
   ansible.builtin.apt:

--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
 - name: Download GPG key
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
     dest: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg_armored
     checksum: sha256:84df2e5fd80d464c3eb9acd2f751b2f6a723438200915dd50fbf12f08698e4ec
+    mode: '0755'
+    force: true
 
 - name: De-Armor GPG key
-  command: gpg --dearmor < /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg_armored > /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
+  ansible.builtin.command: gpg --dearmor < /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg_armored > /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
   no_log: true
   args:
     creates: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg

--- a/packer/linux/ansible/roles/erlang/tasks/main.yml
+++ b/packer/linux/ansible/roles/erlang/tasks/main.yml
@@ -1,28 +1,26 @@
 ---
 - name: Download GPG key
   ansible.builtin.get_url:
-    url: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
-    dest: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg_armored
-    checksum: sha256:84df2e5fd80d464c3eb9acd2f751b2f6a723438200915dd50fbf12f08698e4ec
+    url: "{{ erlang_gpg_key_url }}"
+    dest: "{{ erlang_gpg_key_path }}_armored"
+    checksum: "sha256:{{ erlang_gpg_key_checksum }}"
     mode: '0755'
     force: true
 
 - name: De-Armor GPG key
-  ansible.builtin.command: gpg --dearmor < /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg_armored > /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
+  ansible.builtin.command: gpg --dearmor < {{ erlang_gpg_key_path }}_armored > {{ erlang_gpg_key_path }}
   no_log: true
   args:
-    creates: /usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg
+    creates: "{{ erlang_gpg_key_path }}"
 
 - name: "Add repository to APT sources list"
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
+    repo: "deb [arch=amd64 signed-by={{ erlang_gpg_key_path }}] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
     state: present
-  tags:
-    - skip_ansible_lint
 
 - name: "Add src repository to APT sources list"
   ansible.builtin.apt_repository:
-    repo: "deb-src [signed-by=/usr/share/keyrings/rabbitmq.E495BB49CC4BBE5B.gpg] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
+    repo: "deb-src [signed-by={{ erlang_gpg_key_path }}] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu focal main"
     state: present
 
 - name: Install Erlang


### PR DESCRIPTION
The current Erlang installation from is not working properly - see [this job](https://semaphore.semaphoreci.com/jobs/9dd1cab2-2f1c-4fa8-b7de-9dfe19844783#L559) to inspect the error. This pull request updates the Erlang installation to use the repository maintained by the RabbitMQ team for Erlang versions, which seems to be more stable. See [their guide](https://www.rabbitmq.com/docs/install-debian#erlang-repositories) for more details.