### PR TITLE
increase Windows password complexity

### DIFF
--- a/packer/windows/scripts/start-agent.ps1
+++ b/packer/windows/scripts/start-agent.ps1
@@ -116,12 +116,12 @@ $agentParams = Retry-Command -ScriptBlock {
 
 # Create semaphore password and user
 # This is the user we will use to run the nssm service for the agent
-Add-Type -AssemblyName 'System.Web'
 $UserName = "semaphore"
-$Password = [System.Web.Security.Membership]::GeneratePassword(16, 0)
+Log "Creating '$UserName' user..."
+Add-Type -AssemblyName 'System.Web'
+$Password = [System.Web.Security.Membership]::GeneratePassword(127, 1)
 $PasswordAsSecureString = $Password | ConvertTo-SecureString -AsPlainText -Force
 $Credentials = New-Object System.Management.Automation.PSCredential -ArgumentList ".\$UserName",$PasswordAsSecureString
-Write-Output "Creating '$UserName' user..."
 New-LocalUser -Name $UserName -PasswordNeverExpires -Password $PasswordAsSecureString | out-null
 Add-LocalGroupMember -Group "Administrators" -Member $UserName | out-null
 


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
This drastically increases the complexity of the password used for the `semaphore` user creation during Windows userdata execution.

I saw 2 occurrences of errors in the existing logic:
```
Fetching info from IMDS...
Fetching agent params...
Creating 'semaphore' user...
New-LocalUser : Unable to update the password. The value provided for the new password does not meet the length,
complexity, or history requirements of the domain.
At C:\semaphore-agent\start.ps1:146 char:1
+ New-LocalUser -Name $UserName -PasswordNeverExpires -Password $Passwo ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [New-LocalUser], InvalidPasswordException
    + FullyQualifiedErrorId : InvalidPassword,Microsoft.PowerShell.Commands.NewLocalUserCommand
```

What I've found is 

> In Windows Server 2019, local user password requirements can be configured using Group Policy or the Local Security Policy Editor. By default, passwords must be at least six characters long and contain characters from at least three of the following four categories: uppercase letters, lowercase letters, numbers, and non-alphabetic characters. The system also prevents passwords from containing the user's account name or parts of their full name

> For Windows Server 2019 local users, the maximum password length for user-initiated changes in the logon interface is 127 characters. This is due to a limitation in the Windows logon dialog box itself. 

My belief is that the current logic can sometimes not include 3 of "uppercase letters, lowercase letters, numbers, and non-alphabetic characters". By dramatically increasing the length and forcing the password to contain a symbol, I am hoping that this issue won't happen anymore.

I originally made this change back on Jun 5 to our internal copy of this file. We haven't seen an issue with a Windows agent EC2 instance starting up since.