### PR TITLE
fix: replace AmazonEC2RoleforSSM with AmazonSSMManagedInstanceCore managed policy

### DIFF
--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -160,7 +160,7 @@ class AwsSemaphoreAgentStack extends Stack {
 
   getInstanceProfileRoleManagedPolicies() {
     let managedPolicies = [
-      ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonSSMManagedInstanceCore')
+      ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')
     ];
 
     if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES")) {

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -160,7 +160,7 @@ class AwsSemaphoreAgentStack extends Stack {
 
   getInstanceProfileRoleManagedPolicies() {
     let managedPolicies = [
-      ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEC2RoleforSSM')
+      ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonSSMManagedInstanceCore')
     ];
 
     if (!this.argumentStore.isEmpty("SEMAPHORE_AGENT_MANAGED_POLICY_NAMES")) {

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -141,7 +141,7 @@ describe("instance profile", () => {
       },
       ManagedPolicyArns: [{
         'Fn::Join': ['', [
-          'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonSSMManagedInstanceCore'
+          'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/AmazonSSMManagedInstanceCore'
         ]]
       }]
     });
@@ -167,7 +167,7 @@ describe("instance profile", () => {
       ManagedPolicyArns: [
         {
           'Fn::Join': ['', [
-            'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonSSMManagedInstanceCore'
+            'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/AmazonSSMManagedInstanceCore'
           ]]
         },
         {

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -141,7 +141,7 @@ describe("instance profile", () => {
       },
       ManagedPolicyArns: [{
         'Fn::Join': ['', [
-          'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+          'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonSSMManagedInstanceCore'
         ]]
       }]
     });
@@ -167,7 +167,7 @@ describe("instance profile", () => {
       ManagedPolicyArns: [
         {
           'Fn::Join': ['', [
-            'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+            'arn:', { Ref: 'AWS::Partition' }, ':iam::aws:policy/service-role/AmazonSSMManagedInstanceCore'
           ]]
         },
         {


### PR DESCRIPTION
The [AmazonEC2RoleforSSM](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2RoleforSSM.html) managed policy is overly broad, it includes arbitrary read/write to any S3 bucket in the same AWS account:
```json
  {
      "Effect" : "Allow",
      "Action" : [
        "s3:GetBucketLocation",
        "s3:PutObject",
        "s3:GetObject",
        "s3:GetEncryptionConfiguration",
        "s3:AbortMultipartUpload",
        "s3:ListMultipartUploadParts",
        "s3:ListBucket",
        "s3:ListBucketMultipartUploads"
      ],
      "Resource" : "*"
  }
```
Additionally, this policy is deprecated by AWS:
> This policy will soon be deprecated. Please use AmazonSSMManagedInstanceCore policy to enable AWS Systems Manager service core functionality on EC2 instances. For more information see https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-instance-profile.html

This PR swaps to the recommended policy which is correctly scoped: [AmazonSSMManagedInstanceCore](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html)