### PR TITLE
fix(packer): pin hashicorp/amazon plugin to 1.3.9 to avoid 404 on v1.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-semaphore-agent",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "aws-cdk": "^2.164.1",
         "aws-cdk-lib": "^2.164.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-semaphore-agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "bin": {
     "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
   },

--- a/packer/linux/ubuntu-focal.pkr.hcl
+++ b/packer/linux/ubuntu-focal.pkr.hcl
@@ -44,7 +44,7 @@ variable "systemd_restart_seconds" {
 packer {
   required_plugins {
     amazon = {
-      version = ">= 0.0.2"
+      version = "1.3.9"
       source  = "github.com/hashicorp/amazon"
     }
   }

--- a/packer/macos/macos.pkr.hcl
+++ b/packer/macos/macos.pkr.hcl
@@ -34,7 +34,7 @@ variable "instance_type" {
 packer {
   required_plugins {
     amazon = {
-      version = ">= 0.0.2"
+      version = "1.3.9"
       source  = "github.com/hashicorp/amazon"
     }
   }

--- a/packer/windows/windows.pkr.hcl
+++ b/packer/windows/windows.pkr.hcl
@@ -39,7 +39,7 @@ variable "install_erlang" {
 packer {
   required_plugins {
     amazon = {
-      version = ">= 0.0.2"
+      version = "1.3.9"
       source  = "github.com/hashicorp/amazon"
     }
   }


### PR DESCRIPTION
Building agent images fails when using terraform provider amazon v1.3.10 due to [a missing checksum file](https://semaphore.semaphoreci.com/jobs/4ae4ec48-104e-440b-8f1a-6286e0eab3c4#L365) (packer-plugin-amazon_v1.3.10_SHA256SUMS) on the release page, resulting in a 404 error. Pin to v1.3.9 as a temporary workaround.

See [the related issue](https://github.com/renderedtext/tasks/issues/8459).

Related amazon packer plugin issue: https://github.com/hashicorp/packer-plugin-amazon/issues/586.