### PR TITLE
chore: update minimatch version to 10.2.3 to fix CVEs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,7 +42,12 @@ blocks:
       epilogue:
         always:
           commands:
-            - if [ -f results.xml ]; then test-results publish results.xml; fi
+            - 'if [ -f results.xml ]; then test-results publish results.xml; fi'
+            - 'if [ -f out/dependency-scan-junit.xml ]; then test-results --name "Dependency scan" --suite-prefix "[$SEMAPHORE_BLOCK_NAME]" publish out/dependency-scan-junit.xml; fi'
+            - 'if [ -f out/test-reports.xml ]; then test-results --name "$SEMAPHORE_BLOCK_NAME" publish out/test-reports.xml; fi'
+            - 'if [ -f out/dependency-scan-trivy.json ]; then artifact push workflow out/dependency-scan-trivy.json -d scans/$SEMAPHORE_JOB_ID-dependency-scan-trivy.json; fi'
+            - 'if [ -f out/dependency-scan-junit.xml ]; then artifact push workflow out/dependency-scan-junit.xml -d scans/$SEMAPHORE_JOB_ID-dependency-scan-junit.xml; fi'
+            - 'if [ -f out/test-reports.xml ]; then artifact push workflow out/test-reports.xml -d scans/$SEMAPHORE_JOB_ID-test-reports.xml; fi'
       jobs:
         - name: Check dependencies
           commands:

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -7,7 +7,7 @@ const { Stack, Duration, Fn, CustomResource } = require("aws-cdk-lib");
 const { Provider } = require("aws-cdk-lib/custom-resources");
 const { Rule, Schedule } = require("aws-cdk-lib/aws-events");
 const { LambdaFunction } = require("aws-cdk-lib/aws-events-targets");
-const { RetentionDays } = require("aws-cdk-lib/aws-logs");
+const { LogGroup, RetentionDays } = require("aws-cdk-lib/aws-logs");
 const { StringParameter, ParameterTier } = require("aws-cdk-lib/aws-ssm");
 const { Function, AssetCode } = require("aws-cdk-lib/aws-lambda");
 const { Policy, PolicyStatement, Role, ServicePrincipal, ManagedPolicy, Effect } = require("aws-cdk-lib/aws-iam");
@@ -259,6 +259,10 @@ class AwsSemaphoreAgentStack extends Stack {
   createScalerLambda(lambdaRole) {
     const lambdaDependencies = new DependencyGroup();
     lambdaDependencies.add(lambdaRole);
+    const logGroup = new LogGroup(this, 'scalerLambdaLogGroup', {
+      logGroupName: `/aws/lambda/${this.stackName}-scaler-lambda`,
+      retention: RetentionDays.ONE_MONTH
+    });
 
     let opts = {
       description: `Dynamically scale Semaphore agents based on jobs demand`,
@@ -270,9 +274,7 @@ class AwsSemaphoreAgentStack extends Stack {
       maxEventAge: Duration.minutes(1),
       retryAttempts: 0,
       role: lambdaRole,
-      logGroup: {
-        retention: RetentionDays.ONE_MONTH
-      },
+      logGroup: logGroup,
       environment: {
         "SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME": this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME"),
         "SEMAPHORE_AGENT_STACK_NAME": this.stackName,
@@ -585,6 +587,10 @@ class AwsSemaphoreAgentStack extends Stack {
     });
 
     suspenderPolicy.attachToRole(suspenderRole);
+    const suspenderFunctionLogGroup = new LogGroup(this, 'azRebalanceSuspenderLambdaLogGroup', {
+      logGroupName: `/aws/lambda/${this.stackName}-az-rebalance-suspender-lambda`,
+      retention: RetentionDays.ONE_MONTH
+    });
 
     let suspenderFunction = new Function(this, 'azRebalanceSuspenderLambda', {
       description: "Suspend AZRebalance process for auto scaling group",
@@ -592,16 +598,16 @@ class AwsSemaphoreAgentStack extends Stack {
       code: new AssetCode("lambdas/az-rebalance-suspender"),
       handler: "app.handler",
       role: suspenderRole,
-      logGroup: {
-        retention: RetentionDays.ONE_MONTH
-      }
+      logGroup: suspenderFunctionLogGroup
+    });
+    const providerLogGroup = new LogGroup(this, 'azRebalanceSuspenderProviderLogGroup', {
+      logGroupName: `/aws/lambda/${this.stackName}-az-rebalance-suspender-provider`,
+      retention: RetentionDays.ONE_MONTH
     });
 
     const provider = new Provider(this, "azRebalanceSuspenderProvider", {
       onEventHandler: suspenderFunction,
-      logGroup: {
-        retention: RetentionDays.ONE_MONTH
-      }
+      logGroup: providerLogGroup
     });
 
     return new CustomResource(this, "azRebalanceSuspender", {

--- a/lib/aws-semaphore-agent-stack.js
+++ b/lib/aws-semaphore-agent-stack.js
@@ -3,11 +3,11 @@ const { hash } = require("./ami-hash");
 const { DynamicSSHKeysUpdater } = require("./dynamic-ssh-keys-updater");
 const { nodeJs22Runtime } = require("./nodejs-runtime");
 const { DependencyGroup } = require("constructs");
-const { Stack, Duration, Fn, CustomResource } = require("aws-cdk-lib");
+const { Stack, Duration, CustomResource } = require("aws-cdk-lib");
 const { Provider } = require("aws-cdk-lib/custom-resources");
 const { Rule, Schedule } = require("aws-cdk-lib/aws-events");
 const { LambdaFunction } = require("aws-cdk-lib/aws-events-targets");
-const { LogGroup, RetentionDays } = require("aws-cdk-lib/aws-logs");
+const { RetentionDays } = require("aws-cdk-lib/aws-logs");
 const { StringParameter, ParameterTier } = require("aws-cdk-lib/aws-ssm");
 const { Function, AssetCode } = require("aws-cdk-lib/aws-lambda");
 const { Policy, PolicyStatement, Role, ServicePrincipal, ManagedPolicy, Effect } = require("aws-cdk-lib/aws-iam");
@@ -259,10 +259,6 @@ class AwsSemaphoreAgentStack extends Stack {
   createScalerLambda(lambdaRole) {
     const lambdaDependencies = new DependencyGroup();
     lambdaDependencies.add(lambdaRole);
-    const logGroup = new LogGroup(this, 'scalerLambdaLogGroup', {
-      logGroupName: `/aws/lambda/${this.stackName}-scaler-lambda`,
-      retention: RetentionDays.ONE_MONTH
-    });
 
     let opts = {
       description: `Dynamically scale Semaphore agents based on jobs demand`,
@@ -274,7 +270,7 @@ class AwsSemaphoreAgentStack extends Stack {
       maxEventAge: Duration.minutes(1),
       retryAttempts: 0,
       role: lambdaRole,
-      logGroup: logGroup,
+      logRetention: RetentionDays.ONE_MONTH,
       environment: {
         "SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME": this.argumentStore.get("SEMAPHORE_AGENT_TOKEN_PARAMETER_NAME"),
         "SEMAPHORE_AGENT_STACK_NAME": this.stackName,
@@ -587,10 +583,6 @@ class AwsSemaphoreAgentStack extends Stack {
     });
 
     suspenderPolicy.attachToRole(suspenderRole);
-    const suspenderFunctionLogGroup = new LogGroup(this, 'azRebalanceSuspenderLambdaLogGroup', {
-      logGroupName: `/aws/lambda/${this.stackName}-az-rebalance-suspender-lambda`,
-      retention: RetentionDays.ONE_MONTH
-    });
 
     let suspenderFunction = new Function(this, 'azRebalanceSuspenderLambda', {
       description: "Suspend AZRebalance process for auto scaling group",
@@ -598,16 +590,12 @@ class AwsSemaphoreAgentStack extends Stack {
       code: new AssetCode("lambdas/az-rebalance-suspender"),
       handler: "app.handler",
       role: suspenderRole,
-      logGroup: suspenderFunctionLogGroup
-    });
-    const providerLogGroup = new LogGroup(this, 'azRebalanceSuspenderProviderLogGroup', {
-      logGroupName: `/aws/lambda/${this.stackName}-az-rebalance-suspender-provider`,
-      retention: RetentionDays.ONE_MONTH
+      logRetention: RetentionDays.ONE_MONTH
     });
 
     const provider = new Provider(this, "azRebalanceSuspenderProvider", {
       onEventHandler: suspenderFunction,
-      logGroup: providerLogGroup
+      logRetention: RetentionDays.ONE_MONTH
     });
 
     return new CustomResource(this, "azRebalanceSuspender", {

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -1,9 +1,9 @@
 const { Construct } = require("constructs");
 const { DependencyGroup } = require("constructs");
-const { Duration } = require("aws-cdk-lib");
+const { Stack, Duration } = require("aws-cdk-lib");
 const { Rule, Schedule } = require("aws-cdk-lib/aws-events");
 const { LambdaFunction } = require("aws-cdk-lib/aws-events-targets");
-const { RetentionDays } = require("aws-cdk-lib/aws-logs");
+const { LogGroup, RetentionDays } = require("aws-cdk-lib/aws-logs");
 const { StringParameter, ParameterTier } = require("aws-cdk-lib/aws-ssm");
 const { Function, AssetCode } = require("aws-cdk-lib/aws-lambda");
 const { Policy, PolicyStatement, Role, ServicePrincipal, ManagedPolicy, Effect } = require("aws-cdk-lib/aws-iam");
@@ -59,6 +59,11 @@ class DynamicSSHKeysUpdater extends Construct {
   createUpdaterLambda(role, parameterName) {
     const lambdaDependencies = new DependencyGroup();
     lambdaDependencies.add(role);
+    const stackName = Stack.of(this).stackName;
+    const logGroup = new LogGroup(this, 'LambdaLogGroup', {
+      logGroupName: `/aws/lambda/${stackName}-ssh-keys-updater`,
+      retention: RetentionDays.ONE_MONTH
+    });
 
     let lambdaFunction = new Function(this, 'Lambda', {
       description: `Check if GitHub SSH public keys have changed.`,
@@ -67,9 +72,7 @@ class DynamicSSHKeysUpdater extends Construct {
       code: new AssetCode('lambdas/ssh-keys-updater'),
       handler: 'app.handler',
       role: role,
-      logGroup: {
-        retention: RetentionDays.ONE_MONTH
-      },
+      logGroup: logGroup,
       environment: {
         "SSM_PARAMETER": parameterName
       }

--- a/lib/dynamic-ssh-keys-updater.js
+++ b/lib/dynamic-ssh-keys-updater.js
@@ -1,9 +1,9 @@
 const { Construct } = require("constructs");
 const { DependencyGroup } = require("constructs");
-const { Stack, Duration } = require("aws-cdk-lib");
+const { Duration } = require("aws-cdk-lib");
 const { Rule, Schedule } = require("aws-cdk-lib/aws-events");
 const { LambdaFunction } = require("aws-cdk-lib/aws-events-targets");
-const { LogGroup, RetentionDays } = require("aws-cdk-lib/aws-logs");
+const { RetentionDays } = require("aws-cdk-lib/aws-logs");
 const { StringParameter, ParameterTier } = require("aws-cdk-lib/aws-ssm");
 const { Function, AssetCode } = require("aws-cdk-lib/aws-lambda");
 const { Policy, PolicyStatement, Role, ServicePrincipal, ManagedPolicy, Effect } = require("aws-cdk-lib/aws-iam");
@@ -59,11 +59,6 @@ class DynamicSSHKeysUpdater extends Construct {
   createUpdaterLambda(role, parameterName) {
     const lambdaDependencies = new DependencyGroup();
     lambdaDependencies.add(role);
-    const stackName = Stack.of(this).stackName;
-    const logGroup = new LogGroup(this, 'LambdaLogGroup', {
-      logGroupName: `/aws/lambda/${stackName}-ssh-keys-updater`,
-      retention: RetentionDays.ONE_MONTH
-    });
 
     let lambdaFunction = new Function(this, 'Lambda', {
       description: `Check if GitHub SSH public keys have changed.`,
@@ -72,7 +67,7 @@ class DynamicSSHKeysUpdater extends Construct {
       code: new AssetCode('lambdas/ssh-keys-updater'),
       handler: 'app.handler',
       role: role,
-      logGroup: logGroup,
+      logRetention: RetentionDays.ONE_MONTH,
       environment: {
         "SSM_PARAMETER": parameterName
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.10.0",
       "dependencies": {
         "aws-cdk": "^2.164.1",
-        "aws-cdk-lib": "^2.164.1",
-        "constructs": "^10.2.69"
+        "aws-cdk-lib": "2.248.0",
+        "constructs": "^10.5.0"
       },
       "bin": {
         "aws-semaphore-agent": "bin/aws-semaphore-agent.js"
@@ -34,21 +34,21 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.242",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
-      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
-      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
+      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "45.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-45.2.0.tgz",
-      "integrity": "sha512-5TTUkGHQ+nfuUGwKA8/Yraxb+JdNUh4np24qk/VHXmrCMq+M6HfmGWfhcg/QlHA2S5P3YIamfYHdQAB4uSNLAg==",
+      "version": "53.12.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.12.0.tgz",
+      "integrity": "sha512-xXB5Cu6uHQl8C0uYvS0gQjMwYGWQ/UcifssdzNOgTNxPky2r68mPXEJ1snvsoLhy44X9r2px0riRglIswKX4ug==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -56,7 +56,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.2"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -71,7 +71,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1160,11 +1160,12 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.208.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.208.0.tgz",
-      "integrity": "sha512-lZW475enKz36A/hZvS7xUwfjeqLqxKgBmZ2cGA7BB5PAlQsjBfN70ZGDgGl0egug5fb/hsYy1Dy4OrclfNzxFg==",
+      "version": "2.248.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz",
+      "integrity": "sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==",
       "bundleDependencies": [
         "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
         "case",
         "fs-extra",
         "ignore",
@@ -1178,26 +1179,65 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.242",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^45.2.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.3",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.3",
         "punycode": "^2.3.1",
-        "semver": "^7.7.2",
+        "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "constructs": "^10.0.0"
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.0",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1206,7 +1246,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.18.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1251,17 +1291,22 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -1288,11 +1333,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
@@ -1304,7 +1344,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.0",
       "funding": [
         {
           "type": "github",
@@ -1319,7 +1359,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.0",
+      "version": "11.3.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1358,7 +1398,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1401,14 +1441,17 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "10.2.5",
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
@@ -1428,7 +1471,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1502,7 +1545,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -1858,9 +1901,9 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
-      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,12 +1629,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1852,6 +1854,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -3252,9 +3255,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3628,6 +3632,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-semaphore-agent",
       "version": "0.10.0",
       "dependencies": {
-        "aws-cdk": "^2.164.1",
+        "aws-cdk": "^2.1116.0",
         "aws-cdk-lib": "2.248.0",
         "constructs": "^10.5.0"
       },
@@ -1145,18 +1145,15 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1023.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1023.0.tgz",
-      "integrity": "sha512-DWMA+IrAsBUNF2RvH7ujpDp7wSJkqTkRL8yfK4AYpEjoGY1KMaKIfxz3M3+Nk3ogM7VhZiW3OGWEOgyDF47HOQ==",
+      "version": "2.1116.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1116.0.tgz",
+      "integrity": "sha512-CMB+FUnuuFDgsb3U3TId6JEKpA0vRErpjX2pMR44qxilisKyU8/Z4pJTH1KVRQtXQbLKIXpq73LUVkyIv1jmKQ==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
@@ -2189,6 +2186,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "aws-cdk": "^2.164.1",
     "aws-cdk-lib": "^2.164.1",
     "constructs": "^10.2.69"
+  },
+  "overrides": {
+    "minimatch": "3.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "aws-cdk": "^2.164.1",
-    "aws-cdk-lib": "^2.164.1",
-    "constructs": "^10.2.69"
+    "aws-cdk-lib": "2.248.0",
+    "constructs": "^10.5.0"
   },
   "overrides": {
     "minimatch": "3.1.4"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jest": "^29.3.1"
   },
   "dependencies": {
-    "aws-cdk": "^2.164.1",
+    "aws-cdk": "^2.1116.0",
     "aws-cdk-lib": "2.248.0",
     "constructs": "^10.5.0"
   },

--- a/test/aws-semaphore-agent.test.js
+++ b/test/aws-semaphore-agent.test.js
@@ -950,6 +950,10 @@ describe("host resource group", () => {
             {
               Name: "auto-release-host",
               Values: ["true"]
+            },
+            {
+              Name: "auto-host-recovery",
+              Values: ["true"]
             }
           ],
         },
@@ -1002,6 +1006,10 @@ describe("host resource group", () => {
             },
             {
               Name: "auto-release-host",
+              Values: ["true"]
+            },
+            {
+              Name: "auto-host-recovery",
               Values: ["true"]
             }
           ],


### PR DESCRIPTION
- Fixed `minimatch` v3.1.2 CVEs (reported [here](https://semaphore.semaphoreci.com/jobs/589d8ef0-86de-4bc1-9f39-967ac67a3c80/summary?report_id=a4dc3821-7b5f-3efc-af30-6148a5ce72b7&suite_id=a8900aab-43ac-3d91-8c30-4efea97f3ff5&test_id=ddff9f61-a693-34fc-b9b5-c120f7e6c0c0)): `CVE-2026-27904`, `CVE-2026-26996`, `CVE-2026-27903`.
- Upgraded `aws-cdk-lib` to `2.248.0` and `aws-cdk` to `2.1116.0` for compatibility.
- Fixed unit tests.
- CI now publishes dependency scan test results.

Related [task](https://github.com/renderedtext/tasks/issues/9571).