### PR TITLE
fix(packer/linux): power off bootstrap failure when IMDS has no instance id or IMDS is unreachable

### DIFF
--- a/packer/linux/ansible/roles/agent/files/start-agent.sh
+++ b/packer/linux/ansible/roles/agent/files/start-agent.sh
@@ -3,17 +3,23 @@
 set -eo pipefail
 
 #
-# If anything goes wrong with the instance startup,
-# we make the instance unhealthy, so the auto scaling group can rotate it.
+# If anything goes wrong with the instance startup, mark unhealthy when IMDS returns an
+# instance id; otherwise shut down (AWS calls need IMDS; LT uses terminate on shutdown).
 #
 on_failure() {
   local exit_code=$1
   if [[ $exit_code != 0 ]] ; then
+    set +e
     local __token__=$(fetch_idms_token)
     local __instance_id__=$(curl -H "X-aws-ec2-metadata-token: $__token__" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
-    aws autoscaling set-instance-health \
-      --instance-id "${__instance_id__}" \
-      --health-status Unhealthy
+    if [[ -n "$__instance_id__" ]]; then
+      aws autoscaling set-instance-health \
+        --instance-id "${__instance_id__}" \
+        --health-status Unhealthy
+    else
+      sudo shutdown -h now || sudo poweroff -f || true
+    fi
+    set -e
   fi
 }
 


### PR DESCRIPTION
Issue faced -

```
Cloud-init v. 25.2-0ubuntu1~24.04.1 running 'modules:config' at Mon, 27 Apr 2026 04:14:03 +0000. Up 23.72 seconds.
Cloud-init v. 25.2-0ubuntu1~24.04.1 running 'modules:final' at Mon, 27 Apr 2026 04:14:06 +0000. Up 26.74 seconds.
curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Couldn't connect to server
curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Couldn't connect to server
curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Couldn't connect to server
curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Couldn't connect to server

Parameter validation failed:
Invalid length for parameter InstanceId, value: 0, valid min length: 1
2026-04-27 04:14:10,619 - cc_scripts_user.py[WARNING]: Failed to run module scripts_user (scripts in /var/lib/cloud/instance/scripts)
2026-04-27 04:14:10,633 - log_util.py[WARNING]: Running module scripts_user (<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_scripts_user.py'>) failed
```