### PR TITLE
chore(security): Ignore blocking CVEs until they are fixed upstream

### DIFF
--- a/js-ignore-policy.rego
+++ b/js-ignore-policy.rego
@@ -1,0 +1,17 @@
+package trivy
+
+default ignore = false
+
+ignore {
+	deny_vulnerability_ids := {
+		#
+		# aws-cdk-lib bundles fast-uri inside its published tarball.
+		# The latest published aws-cdk-lib release still embeds the vulnerable copy,
+		# so this repository cannot remediate these findings without a CDK upstream fix.
+		#
+		"CVE-2026-6321",
+		"CVE-2026-6322"
+	}
+
+	input.VulnerabilityID = deny_vulnerability_ids[_]
+}


### PR DESCRIPTION
The two CVEs that are blocking the CI process are caused by the **fast-uri** dependency.
The **aws-cdk-lib** bundles **fast-uri** inside its published tarball.
The latest published **aws-cdk-lib** release still embeds the vulnerable copy, so we can only ignore it until the new version with the fix is published.